### PR TITLE
Add basic release build automation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+---
+name: Release
+on:
+  release:
+    type: [created]
+jobs:
+  build:
+    name: 'Build and Publish Artifacts'
+    runs-on: ubuntu-latest
+    stages:
+      - name: 'Checkout Sources'
+        uses: actions/checkout@v2
+      - name: 'Prepare Node.js'
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: 'Fetch Dependencies'
+        run: npm install
+      - name: 'Build Dashboard'
+        run: npm run build
+      - name: 'Prepare Tarball'
+        run: tar -cvzf ./dashboard.tar.gz build/
+      - name: 'Upload Tarball'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_path: ./dashboard.tar.gz
+          asset_name: dashboard.tar.gz
+          asset_content_type: application/gzip
+          upload_url: ${{ github.event.release.upload_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: 'Build and Publish Artifacts'
     runs-on: ubuntu-latest
-    stages:
+    steps:
       - name: 'Checkout Sources'
         uses: actions/checkout@v2
       - name: 'Prepare Node.js'


### PR DESCRIPTION
When a new release is created, this will automatically build the dashboard and add a rlease asset containing a compressed tarball of the build directory.

Long-term, this can be easily expanded to publish to NPM (if we choose to do so) and open a PR against https://github.com/netdata/netdata to update the packaging code there to use the newly released version of the dashboard.

Closes: #26 