### PR TITLE
Run tests and linter against PR's.

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -1,0 +1,28 @@
+---
+name: Pull Request NPM Checks
+on: [pull_request]
+jobs:
+  npm-test:
+    name: NPM test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+      - name: Prepare Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Run `npm test`
+        run: npm test
+  npm-lint:
+    name: NPM lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+      - name: Prepare Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Run `npm run lint`
+        run: npm run lint

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - name: Run `npm install`
+        run: npm install
       - name: Run `npm test`
         run: npm test
   npm-lint:
@@ -24,5 +26,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - name: Run `npm install`
+        run: npm install
       - name: Run `npm run lint`
         run: npm run lint


### PR DESCRIPTION
This adds a GitHub Actions workflow to run `npm test` and `npm run lint` against PR's. They will show up as separate checks in the PR checks list.

Behavior can be observed on this PR (GitHub Actions use the configuration from the PR itself when running against a PR).

Based on discussion with @jacekkolasa on Slack.