### PR TITLE
Fix syntax issue in release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@
 name: Release
 on:
   release:
-    type: [created]
+    types:
+      - created
 jobs:
   build:
     name: 'Build and Publish Artifacts'


### PR DESCRIPTION
This will ensure it only runs once on relase creation, so that we don't have failures do to multiple upload attempts.