### PR TITLE
fix-cloud-timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -28,7 +28,7 @@ import {
   fetchDataForSnapshotAction, FetchDataForSnapshotPayload, fetchInfoAction, FetchInfoPayload,
 } from "./actions"
 
-const CONCURRENT_CALLS_LIMIT_METRICS = 20
+const CONCURRENT_CALLS_LIMIT_METRICS = isMainJs ? 30 : 60
 const CONCURRENT_CALLS_LIMIT_PRINT = 2
 const CONCURRENT_CALLS_LIMIT_SNAPSHOTS = 1
 

--- a/src/domains/chart/utils/get-chart-pixels-per-point.ts
+++ b/src/domains/chart/utils/get-chart-pixels-per-point.ts
@@ -10,12 +10,14 @@ export const getChartPixelsPerPoint: GetChartPixelsPerPoint = ({
   attributes, chartSettings,
 }) => {
   const {
-    pixelsPerPoint: pixelsPerPointAttribute = 1,
+    pixelsPerPoint: pixelsPerPointAttribute,
   } = attributes
+  if (typeof pixelsPerPointAttribute === "number") {
+    return pixelsPerPointAttribute
+  }
   const pixelsPerPointSetting = chartSettings.pixelsPerPoint(attributes)
 
   return Math.max(...[
-    pixelsPerPointAttribute,
     pixelsPerPointSetting,
     window.NETDATA.options.current.pixels_per_point,
   ].filter((px) => typeof px === "number"))

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,7 +1,6 @@
 import axios from "axios"
 
 export const axiosInstance = axios.create({
-  // timeout: 30 * 1000, // todo
   headers: {
     "Cache-Control": "no-cache, no-store",
     Pragma: "no-cache",

--- a/src/utils/netdata-sdk/metrics-stream.ts
+++ b/src/utils/netdata-sdk/metrics-stream.ts
@@ -16,6 +16,8 @@ interface FetchInputEvent {
   onSuccessCallback: (data: { [key: string]: unknown }) => void
 }
 
+const METRICS_TIMEOUT = 15_000
+
 export const getFetchStream = (concurrentCallsLimit: number) => {
   const fetch$ = new Subject<FetchInputEvent>()
   const resetFetch$ = new Subject()
@@ -23,7 +25,7 @@ export const getFetchStream = (concurrentCallsLimit: number) => {
   const handler = mergeMap(({
     url, params, onErrorCallback, onSuccessCallback,
   }: FetchInputEvent) => (
-    from(axiosInstance.get(url, { params })).pipe(
+    from(axiosInstance.get(url, { params, timeout: METRICS_TIMEOUT })).pipe(
       tap(({ data }) => { onSuccessCallback(data) }),
       catchError(() => {
         // todo implement error handling to support NETDATA.options.current.retries_on_data_failures


### PR DESCRIPTION
set timeout for metrics-data calls, to 15s
attributes.pointsPerPixes is now overwriting existing settings even if it's lower (previously it was Math.max() with settings/defaults)
allowed more simultaneus calls (60 for cloud)