### PR TITLE
remove notifications and fix /default.html route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { useAlarms } from "hooks/use-alarms"
 
 import "./types/global"
 
-import { useInfo } from "hooks/use-info"
+// import { useInfo } from "hooks/use-info"
 import { serverStatic } from "utils/server-detection"
 import {
   netdataCallback,
@@ -80,7 +80,7 @@ const App: React.FC = () => { // eslint-disable-line arrow-body-style
 
   useRegistry(true)
   useAlarms(true)
-  useInfo(true)
+  // useInfo(true)
 
   const [hasFetchDependencies, setHasFetchDependencies] = useState(false)
   useLayoutEffect(() => {

--- a/src/utils/server-detection.ts
+++ b/src/utils/server-detection.ts
@@ -42,7 +42,11 @@ const getDefaultServer = () => {
   // Agent Dashboard does not need sophisticated server-detection, which is causing problems
   // when navigating through streamed nodes. Let's overwrite that setting
   if (isMainJs) {
-    return window.location.origin + window.location.pathname.replace("index.html", "")
+    const pathname = window.location.pathname
+      .replace("index.html", "")
+      // todo consider .replace(/[^\/]*\.html/, "") (every .html file in the url)
+      .replace("default.html", "") // for netdata demo servers
+    return window.location.origin + pathname
   }
 
   const source = getScriptSource()


### PR DESCRIPTION
@VLegakis i disabled the notifications for now, i know that your PR contains the fix, but i don't have time for testing this, let's just not have notifications and /api/v1/info polling at all next stable release (after weekend)