### PR TITLE
sparkline - force time window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/components/abstract-chart.tsx
+++ b/src/domains/chart/components/abstract-chart.tsx
@@ -187,6 +187,7 @@ export const AbstractChart = ({
         isRemotelyControlled={isRemotelyControlled}
         orderedColors={orderedColors}
         unitsCurrent={unitsCurrent}
+        requestedViewRange={requestedViewRange}
       />
     )
   }

--- a/src/domains/chart/components/lib-charts/sparkline-chart.tsx
+++ b/src/domains/chart/components/lib-charts/sparkline-chart.tsx
@@ -6,6 +6,40 @@ import React, {
 import { Attributes } from "domains/chart/utils/transformDataAttributes"
 import { ChartMetadata, EasyPieChartData } from "domains/chart/chart-types"
 import { colorLuminance } from "domains/chart/utils/color-luminance"
+import { MS_IN_SECOND } from "utils"
+import { TimeRange } from "types/common"
+
+const convertToTimestamp = (number: number) => {
+  if (number > 0) {
+    return number
+  }
+  return new Date().valueOf() + number // number is negative or zero
+}
+
+interface TimeWindowCorrection {
+  paddingLeftPercentage?: string
+  widthRatio?: number
+}
+const getForceTimeWindowCorrection = (
+  chartData: EasyPieChartData, requestedViewRange: TimeRange,
+): TimeWindowCorrection => {
+  const requestedAfter = convertToTimestamp(requestedViewRange[0])
+  const requestedBefore = convertToTimestamp(requestedViewRange[1])
+  const after = chartData.after * MS_IN_SECOND
+  const before = chartData.before * MS_IN_SECOND
+
+  const currentDuration = before - after
+  const requestedDuration = requestedBefore - requestedAfter
+  const widthRatio = (currentDuration / requestedDuration)
+
+  const visibleDuration = requestedBefore - requestedAfter
+  const paddingLeftPercentage = `${100 * ((after - requestedAfter) / visibleDuration)}%`
+
+  return {
+    paddingLeftPercentage,
+    widthRatio,
+  }
+}
 
 interface Props {
   attributes: Attributes
@@ -18,6 +52,7 @@ interface Props {
   isRemotelyControlled: boolean
   orderedColors: string[]
   unitsCurrent: string
+  requestedViewRange: TimeRange
 }
 export const SparklineChart = ({
   attributes,
@@ -28,12 +63,17 @@ export const SparklineChart = ({
   chartElementId,
   orderedColors,
   unitsCurrent,
+  requestedViewRange,
 }: Props) => {
   const chartElement = useRef<HTMLDivElement>(null)
 
   // update width, height automatically each time
   const [$chartElement, set$chartElement] = useState()
   const sparklineOptions = useRef<{[key: string]: any}>()
+
+  const { paddingLeftPercentage = undefined, widthRatio = 1 } = attributes.forceTimeWindow
+    ? getForceTimeWindowCorrection(chartData, requestedViewRange)
+    : {}
 
   // create chart
   useEffect(() => {
@@ -107,7 +147,7 @@ export const SparklineChart = ({
         numberDecimalMark: attributes.sparklineNumberDecimalMark,
         numberDigitGroupCount: attributes.sparklineNumberDigitGroupCount,
         animatedZooms: attributes.sparklineAnimatedZooms,
-        width: Math.floor(width),
+        width: Math.floor(width * widthRatio),
         height: Math.floor(height),
       }
 
@@ -117,7 +157,7 @@ export const SparklineChart = ({
       $element.sparkline(chartData.result, sparklineInitOptions)
     }
   }, [$chartElement, attributes, chartContainerElement, chartData.result, chartMetadata,
-    orderedColors, unitsCurrent])
+    orderedColors, unitsCurrent, widthRatio])
 
   // update chart
   useEffect(() => {
@@ -125,13 +165,18 @@ export const SparklineChart = ({
       const { width, height } = chartContainerElement.getBoundingClientRect()
       $chartElement.sparkline(chartData.result, {
         ...sparklineOptions.current,
-        width: Math.floor(width),
+        width: Math.floor(width * widthRatio),
         height: Math.floor(height),
       })
     }
   })
 
+  const style = paddingLeftPercentage ? {
+    textAlign: "initial" as "initial", // :) typescript
+    paddingLeft: paddingLeftPercentage,
+  } : undefined
+
   return (
-    <div ref={chartElement} id={chartElementId} className={chartElementClassName} />
+    <div ref={chartElement} id={chartElementId} className={chartElementClassName} style={style} />
   )
 }

--- a/src/domains/chart/utils/transformDataAttributes.ts
+++ b/src/domains/chart/utils/transformDataAttributes.ts
@@ -90,6 +90,7 @@ export interface StaticAttributes {
   commonColors?: string
   decimalDigits?: number
   dimensions?: string
+  forceTimeWindow?: boolean
 
   appendOptions?: string | undefined
   gtime?: number
@@ -315,6 +316,7 @@ const getAttributesMap = (): AttributesMap => ({
   commonColors: { key: "common-colors" },
   decimalDigits: { key: "decimal-digits" },
   dimensions: { key: "dimensions" },
+  forceTimeWindow: { key: "force-time-window" },
 
   appendOptions: { key: "append-options" },
   gtime: { key: "gtime" },


### PR DESCRIPTION
new forceTimeWindow attribute, with support in sparkline-chart. It displays time-range as requested, even when there are no available data

I decided just to make the chart smaller in this case and shift it via padding-left. First i was trying to do it on library-level, but the only option was to add nulls (empty points). Given much higher resolution (instead of 30 days user could get 2 hours, still spreading across hundreds points) the array was too big and it was not performant. 