### PR TITLE
netdata-1-21-fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "start:console": "cp ../console.html public/index.html && npm run start",
     "start:tv": "cd public && rm ./index.html && ln -s ../tv.html index.html && cd .. && npm run start",
     "start:dashboard": "REACT_APP_IS_MAIN_DASHBOARD=true npm run start",
-    "build": "REACT_APP_IS_MAIN_DASHBOARD=true REACT_APP_SHOULD_USE_DEFAULT_CONTEXT=true react-scripts build --profile",
+    "build": "REACT_APP_IS_MAIN_DASHBOARD=true REACT_APP_SHOULD_USE_DEFAULT_CONTEXT=true react-scripts build",
     "test": "REACT_APP_SHOULD_USE_DEFAULT_CONTEXT=true react-scripts test --env=jest-environment-jsdom-fourteen --watchAll=false",
     "lint": "eslint --ext .jsx,.js,.tsx,.ts .",
     "clean": "./node_modules/rimraf/bin.js ./lib",

--- a/src/domains/chart/actions.ts
+++ b/src/domains/chart/actions.ts
@@ -1,4 +1,5 @@
 import { createAction } from "redux-act"
+import { CancelTokenSource } from "axios"
 
 import { createRequestAction } from "utils/createRequestAction"
 
@@ -40,6 +41,7 @@ export interface FetchDataUrlParams {
 export interface FetchDataPayload extends FetchDataUrlParams {
   id: string,
   fetchDataParams: FetchDataParams
+  cancelTokenSource: CancelTokenSource
 }
 
 export const fetchDataAction = createRequestAction<

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -23,9 +23,14 @@ import { isPrintMode } from "domains/dashboard/utils/parse-url"
 
 import { INFO_POLLING_FREQUENCY, NOTIFICATIONS_TIMEOUT } from "domains/global/constants"
 import {
-  fetchDataAction, FetchDataPayload,
-  fetchChartAction, FetchChartPayload,
-  fetchDataForSnapshotAction, FetchDataForSnapshotPayload, fetchInfoAction, FetchInfoPayload,
+  fetchDataAction,
+  FetchDataPayload,
+  fetchChartAction,
+  FetchChartPayload,
+  fetchDataForSnapshotAction,
+  FetchDataForSnapshotPayload,
+  fetchInfoAction,
+  FetchInfoPayload,
 } from "./actions"
 
 const CONCURRENT_CALLS_LIMIT_METRICS = isMainJs ? 30 : 60
@@ -80,7 +85,7 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
     // props for api
     host, chart, format, points, group, gtime, options, after, before, dimensions,
     // props for the store
-    fetchDataParams, id,
+    fetchDataParams, id, cancelTokenSource,
   } = payload
 
   const snapshot = yield select(selectSnapshot)
@@ -140,6 +145,7 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
     params,
     onErrorCallback,
     onSuccessCallback,
+    cancelTokenSource,
   })
 }
 

--- a/src/hooks/use-common-intersection.ts
+++ b/src/hooks/use-common-intersection.ts
@@ -50,9 +50,6 @@ export const useCommonIntersection = (
   // the ref is just to prevent most updates on init - charts are not visible on first intersection
   // observer callback, but it still tries to set the state. UseState does not bail out when
   // state doesn't change
-  useEffect(() => {
-    isVisibleRef.current = isVisible
-  }, [isVisible])
 
   useEffect(() => {
     if (typeof IntersectionObserver === "function") {
@@ -60,6 +57,8 @@ export const useCommonIntersection = (
         element,
         (newIsVisible) => {
           if (isVisibleRef.current !== newIsVisible) {
+            isVisibleRef.current = newIsVisible
+            // we need to mirror it in `use-state` to cause react update
             setIsVisible(newIsVisible)
           }
         },


### PR DESCRIPTION
- fix race condition in intersection observer. UseEffect was firing later than intersection observer making sequential callback, which caused unsync

- remove profile flag from build task (that looks scary, but it had minor impact on performance when i tested it)

- cancel request when chart goes out of view