### PR TITLE
netdata-1-21-fix-extended

### DIFF
--- a/src/domains/chart/components/abstract-chart.tsx
+++ b/src/domains/chart/components/abstract-chart.tsx
@@ -265,7 +265,6 @@ export const AbstractChart = ({
       dimensionsVisibility={dimensionsVisibility}
       hasEmptyData={hasEmptyData}
       isRemotelyControlled={isRemotelyControlled}
-      legendFormatValue={legendFormatValue}
       orderedColors={orderedColors}
       hoveredRow={hoveredRow}
       hoveredX={hoveredX}

--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -349,7 +349,7 @@ export const Chart = memo(({
         hoveredX={hoveredX}
         hoveredRow={hoveredRow}
         setHoveredX={handleSetHoveredX}
-        setMinMax={([min, max]) => { legendFormatValueDecimalsFromMinMax(min, max) }}
+        setMinMax={([min, max]) => legendFormatValueDecimalsFromMinMax(min, max)}
         showLatestOnBlur={showLatestOnBlur}
         unitsCurrent={unitsCurrent}
         viewAfter={viewAfter}

--- a/src/domains/chart/components/disable-out-of-view.tsx
+++ b/src/domains/chart/components/disable-out-of-view.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useLayoutEffect, useState,
+  useEffect, useLayoutEffect, useState, useRef,
 } from "react"
 import { useDebounce } from "react-use"
 import { forEachObjIndexed } from "ramda"
@@ -19,8 +19,8 @@ import { InvisibleSearchableText } from "./invisible-searchable-text"
 const SCROLL_DEBOUNCE_ASYNC = 750
 const SCROLL_DEBOUNCE_SYNC = 100
 
-const cloneWithCanvas = (element: Element) => {
-  const cloned = element.cloneNode(true) as Element
+const cloneWithCanvas = (element: HTMLElement) => {
+  const cloned = element.cloneNode(true) as HTMLElement
   const clonedCanvases = cloned.querySelectorAll("canvas")
 
   element.querySelectorAll("canvas")
@@ -82,7 +82,9 @@ export const DisableOutOfView = ({
 
 
   const destroyOnHide = useSelector(selectDestroyOnHide)
-  const isVisibleIntersection = useCommonIntersection(portalNode)
+
+  const clonedChildrenRef = useRef<HTMLElement>()
+  const isVisibleIntersection = useCommonIntersection(portalNode, clonedChildrenRef)
 
   // todo hook to scroll (observe on visible items) instead of changes in intersectionRatio
   // because intersectinnRatio maxes out on 1.0 when element is fully visible
@@ -101,7 +103,13 @@ export const DisableOutOfView = ({
   )
   const shouldHide = isVisibleIntersection ? shouldHideDebounced : true
 
-  const [clonedChildren, setClonedChildren] = useState<Element[]>()
+  const previousIsVisibleIntersection = useRef(isVisibleIntersection)
+  if (clonedChildrenRef.current
+    && previousIsVisibleIntersection.current !== isVisibleIntersection
+  ) {
+    previousIsVisibleIntersection.current = isVisibleIntersection
+  }
+
 
   if (isPrintMode) {
     // we should show everything in this case
@@ -116,10 +124,18 @@ export const DisableOutOfView = ({
       )
     }
 
-    if (!clonedChildren) {
+    if (!clonedChildrenRef.current) {
       const newClonedChildren = Array.from(portalNode.children)
-        .map((child) => cloneWithCanvas(child))
-      setClonedChildren(newClonedChildren)
+        .map((child) => cloneWithCanvas(child as HTMLElement))
+
+      const clonedChildrenContainer = document.createElement("div")
+      clonedChildrenContainer.style.display = "none"
+
+      newClonedChildren.forEach((child) => {
+        clonedChildrenContainer.appendChild(child)
+      })
+
+      clonedChildrenRef.current = clonedChildrenContainer
     }
 
     return (
@@ -127,10 +143,8 @@ export const DisableOutOfView = ({
         <InvisibleSearchableText attributes={attributes} />
         <div
           ref={(nodeElement) => {
-            if (nodeElement && clonedChildren) {
-              clonedChildren.forEach((child: Element) => {
-                nodeElement.appendChild(child)
-              })
+            if (nodeElement && clonedChildrenRef.current) {
+              nodeElement.appendChild(clonedChildrenRef.current)
             }
           }}
         />
@@ -138,8 +152,8 @@ export const DisableOutOfView = ({
     )
   }
 
-  if (!destroyOnHide && clonedChildren) {
-    setClonedChildren(undefined)
+  if (!destroyOnHide && clonedChildrenRef.current) {
+    clonedChildrenRef.current = undefined
   }
 
   return children

--- a/src/domains/chart/components/disable-out-of-view.tsx
+++ b/src/domains/chart/components/disable-out-of-view.tsx
@@ -129,7 +129,7 @@ export const DisableOutOfView = ({
         .map((child) => cloneWithCanvas(child as HTMLElement))
 
       const clonedChildrenContainer = document.createElement("div")
-      clonedChildrenContainer.style.display = "none"
+      clonedChildrenContainer.style.visibility = "hidden"
 
       newClonedChildren.forEach((child) => {
         clonedChildrenContainer.appendChild(child)

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -1,6 +1,6 @@
 import { sortBy } from "ramda"
 import React, {
-  useLayoutEffect, useRef, useCallback, RefObject,
+  useLayoutEffect, useRef, useCallback,
 } from "react"
 import { useUpdateEffect, useUnmount } from "react-use"
 import Dygraph from "dygraphs"

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -50,7 +50,7 @@ interface GetInitialDygraphOptions {
   dimensionsVisibility: boolean[]
   hiddenLabelsElementId: string,
   orderedColors: string[],
-  propsRef: RefObject<{ legendFormatValue: (v: number) => string | number }>
+  setMinMax: (minMax: TimeRange) => void
   shouldSmoothPlot: boolean,
   unitsCurrent: string,
   xAxisTimeString: (d: Date) => string,
@@ -63,7 +63,7 @@ const getInitialDygraphOptions = ({
   dimensionsVisibility,
   hiddenLabelsElementId,
   orderedColors,
-  propsRef,
+  setMinMax,
   shouldSmoothPlot,
   unitsCurrent,
   xAxisTimeString,
@@ -240,9 +240,17 @@ const getInitialDygraphOptions = ({
         axisLabelWidth: dygraphYAxisLabelWidth,
         drawAxis: isSparkline ? false : dygraphDrawYAxis,
         // axisLabelFormatter is added on the updates
-        axisLabelFormatter: (y: Date | number) => (
-          propsRef.current && propsRef.current.legendFormatValue(y as number)
-        ),
+        axisLabelFormatter(y: Date | number) {
+          const formatter = setMinMax([
+            // @ts-ignore
+            // eslint-disable-next-line no-underscore-dangle
+            this.axes_[0].extremeRange[0],
+            // @ts-ignore
+            // eslint-disable-next-line no-underscore-dangle
+            this.axes_[0].extremeRange[1],
+          ]) as unknown as ((value: Date | number) => string)
+          return formatter(y as number)
+        },
       },
     },
   }
@@ -262,7 +270,6 @@ interface Props {
   dimensionsVisibility: boolean[]
   hasEmptyData: boolean
   isRemotelyControlled: boolean
-  legendFormatValue: (v: number) => number | string
   onUpdateChartPanAndZoom: (arg: {
     after: number, before: number,
     callback: (after: number, before: number) => void,
@@ -293,7 +300,6 @@ export const DygraphChart = ({
   dimensionsVisibility,
   hasEmptyData,
   isRemotelyControlled,
-  legendFormatValue,
   onUpdateChartPanAndZoom,
   orderedColors,
 
@@ -374,7 +380,6 @@ export const DygraphChart = ({
     globalChartUnderlay,
     hoveredX,
     // put it to ref to prevent additional updateOptions() after creating dygraph
-    legendFormatValue,
     resetGlobalPanAndZoom,
     setGlobalChartUnderlay,
     viewAfter,
@@ -384,12 +389,11 @@ export const DygraphChart = ({
     propsRef.current.chartData = chartData
     propsRef.current.hoveredX = hoveredX
     propsRef.current.globalChartUnderlay = globalChartUnderlay
-    propsRef.current.legendFormatValue = legendFormatValue
     propsRef.current.resetGlobalPanAndZoom = resetGlobalPanAndZoom
     propsRef.current.setGlobalChartUnderlay = setGlobalChartUnderlay
     propsRef.current.viewAfter = viewAfter
     propsRef.current.viewBefore = viewBefore
-  }, [chartData, globalChartUnderlay, hoveredX, legendFormatValue, resetGlobalPanAndZoom,
+  }, [chartData, globalChartUnderlay, hoveredX, resetGlobalPanAndZoom,
     setGlobalChartUnderlay, viewAfter, viewBefore])
 
   const shouldSmoothPlot = useSelector(selectSmoothPlot)
@@ -403,7 +407,7 @@ export const DygraphChart = ({
         dimensionsVisibility,
         hiddenLabelsElementId,
         orderedColors,
-        propsRef,
+        setMinMax,
         shouldSmoothPlot,
         unitsCurrent,
         xAxisTimeString,
@@ -781,9 +785,6 @@ export const DygraphChart = ({
       // updated with proper formatting (toggle visibility with css)
       const instance = new Dygraph((chartElement.current), chartData.result.data, dygraphOptions)
       dygraphInstance.current = instance
-
-      const extremes = (instance as NetdataDygraph).yAxisExtremes()[0]
-      setMinMax(extremes)
     }
   }, [attributes, chartData, chartMetadata, chartSettings, chartUuid, dimensionsVisibility,
     globalChartUnderlay, hasEmptyData, hiddenLabelsElementId, isMouseDown,

--- a/src/hooks/use-common-intersection.ts
+++ b/src/hooks/use-common-intersection.ts
@@ -61,9 +61,8 @@ export const useCommonIntersection = (
         (newIsVisible) => {
           if (isVisibleRef.current !== newIsVisible) {
             if (clonedChildrenRef.current) {
-              // @ts-ignore
               // eslint-disable-next-line no-param-reassign
-              clonedChildrenRef.current.style.display = newIsVisible ? "block" : "none"
+              clonedChildrenRef.current.style.visibility = newIsVisible ? "visible" : "hidden"
             }
 
             isVisibleRef.current = newIsVisible

--- a/src/hooks/use-common-intersection.ts
+++ b/src/hooks/use-common-intersection.ts
@@ -1,4 +1,6 @@
-import { useEffect, useRef, useState } from "react"
+import {
+  useEffect, useRef, useState, MutableRefObject,
+} from "react"
 
 const globalIntersectionOptions = {
   root: null,
@@ -44,6 +46,7 @@ const globalIntersectionObserver = createGlobalIntersectionObserver()
 //    https://github.com/thebuilder/react-intersection-observer does)
 export const useCommonIntersection = (
   element: HTMLElement,
+  clonedChildrenRef: MutableRefObject<HTMLElement | undefined>,
 ) => {
   const [isVisible, setIsVisible] = useState(false)
   const isVisibleRef = useRef(isVisible)
@@ -57,6 +60,12 @@ export const useCommonIntersection = (
         element,
         (newIsVisible) => {
           if (isVisibleRef.current !== newIsVisible) {
+            if (clonedChildrenRef.current) {
+              // @ts-ignore
+              // eslint-disable-next-line no-param-reassign
+              clonedChildrenRef.current.style.display = newIsVisible ? "block" : "none"
+            }
+
             isVisibleRef.current = newIsVisible
             // we need to mirror it in `use-state` to cause react update
             setIsVisible(newIsVisible)
@@ -67,7 +76,7 @@ export const useCommonIntersection = (
     return () => {
       globalIntersectionObserver.unsubscribe(element)
     }
-  }, [element])
+  }, [clonedChildrenRef, element])
 
   return isVisible
 }


### PR DESCRIPTION
This is an fix-extension. I'm putting it in separate PR, because it's a bigger change and until we decide to fix the stable release, it's good to have both versions available.

This will go as v0.4.14 to `netdata`

Change the way we freeze elements. Clone it (so it's decoupled from React), but don't store the clone in state (to prevent updates), instead keep in ref for instant access. Update the clone's visibility based on Intersection Observer, changing the visibility immediately when it's in the scope. But note - the chart is starting to render after some async timeout (shouldHideDebounced property)