### PR TITLE
Expose version control component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/components/app-header/components/version-control/version-control.tsx
+++ b/src/components/app-header/components/version-control/version-control.tsx
@@ -74,7 +74,7 @@ export const VersionControl = ({
     true,
   )
 
-  const [gcsVersionResponse] = useHttp<{mediaLink: string}>(
+  const [gcsVersionResponse] = useHttp<{ mediaLink: string }>(
     NETDATA_LATEST_GCS_VERSION_URL,
     !isStableReleaseChannel,
   )

--- a/src/index-npm.ts
+++ b/src/index-npm.ts
@@ -34,3 +34,5 @@ export { ChartContainer } from "domains/chart/components/chart-container"
 export { NodeView } from "domains/dashboard/components/node-view"
 
 export { resetGlobalPanAndZoomAction, setGlobalPanAndZoomAction } from "domains/global/actions"
+
+export { VersionControl } from "components/app-header/components/version-control"


### PR DESCRIPTION
The dashboard uses already a Version Control component making all the necessary calls and handling which I expose with this PR since we can easily reuse on the cloud for the required UI 
https://www.figma.com/file/OyGGjJd0Dm7GnscRvSP3Fk/%E2%9C%85S3.3---Node-View?node-id=0%3A1
https://github.com/netdata/product/issues/693
Overall they will look exactly the same as in the agent Nav bars. So better avoid any duplicate code and handling by exposing this component and reusing it in the cloud.