### PR TITLE
8581-special-chars-private-registry

### DIFF
--- a/src/domains/global/sagas.ts
+++ b/src/domains/global/sagas.ts
@@ -102,8 +102,8 @@ const accessRegistry: AccessRegistry = ({
   params: {
     action: "access",
     machine: machineGuid,
-    name: encodeURIComponent(name),
-    url: encodeURIComponent(url),
+    name,
+    url,
   },
   withCredentials: true, // required for the cookie
 }).then(({ data }) => {


### PR DESCRIPTION
8581: fix for encoded chars in urls: don't encode url and name for private registry (axios already does that, which resulted in wrong double encoding)

fixes https://github.com/netdata/netdata/issues/8581