### PR TITLE
dygraph resize and api throttling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/components/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader.tsx
@@ -30,6 +30,7 @@ import {
   selectChartFetchDataParams,
   makeSelectChartMetadataRequest,
   selectChartPanAndZoom,
+  selectChartIsFetchingData,
 } from "../selectors"
 import {
   ChartData,
@@ -108,6 +109,10 @@ export const ChartWithLoader = ({
     state, { id: chartUuid },
   ))
   const chartData = useSelector((state: AppStateT) => selectChartData(state, { id: chartUuid }))
+  const isFetchingData = useSelector((state: AppStateT) => selectChartIsFetchingData(
+    state,
+    { id: chartUuid },
+  ))
 
   const hoveredX = useSelector(selectGlobalSelection)
 
@@ -169,7 +174,7 @@ export const ChartWithLoader = ({
    * fetch data
    */
   useEffect(() => {
-    if (shouldFetch && actualChartMetadata) {
+    if (shouldFetch && actualChartMetadata && !isFetchingData) {
       // todo can be overriden by main.js
       const forceDataPoints = window.NETDATA.options.force_data_points
 
@@ -249,6 +254,7 @@ export const ChartWithLoader = ({
     host,
     initialAfter,
     initialBefore,
+    isFetchingData,
     isPanAndZoomMaster,
     isRemotelyControlled,
     panAndZoom,

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -18,6 +18,7 @@ import {
   selectGlobalSelectionMaster,
   selectSmoothPlot,
   selectSyncPanAndZoom,
+  selectSpacePanelTransitionEndIsActive,
 } from "domains/global/selectors"
 import {
   resetGlobalPanAndZoomAction, setCommonMaxAction, setCommonMinAction,
@@ -808,6 +809,16 @@ export const DygraphChart = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globalChartUnderlay])
+
+  const spacePanelTransitionEndIsActive = useSelector(selectSpacePanelTransitionEndIsActive)
+  useUpdateEffect(() => {
+    if (dygraphInstance.current) {
+      // dygraph always resizes on browser width change, but doesn't resize when the container
+      // has different width.
+      // @ts-ignore
+      dygraphInstance.current.resize()
+    }
+  }, [spacePanelTransitionEndIsActive])
 
   // update data of the chart
   // first effect should only be made by new DygraphInstance()

--- a/src/domains/chart/selectors.ts
+++ b/src/domains/chart/selectors.ts
@@ -43,6 +43,11 @@ export const selectChartViewRange = createSelector(
   (chartState) => chartState.fetchDataParams.viewRange,
 )
 
+export const selectChartIsFetchingData = createSelector(
+  selectSingleChartState,
+  (chartState) => chartState.isFetchingData,
+)
+
 export const selectChartFetchDataParams = createSelector(
   selectSingleChartState,
   (chartState) => chartState.fetchDataParams,

--- a/src/domains/global/options.ts
+++ b/src/domains/global/options.ts
@@ -2,14 +2,16 @@ import { mergeAll, mergeRight } from "ramda"
 import { LOCALSTORAGE_HEIGHT_KEY_PREFIX } from "domains/chart/components/resize-handler"
 
 export const SYNC_PAN_AND_ZOOM = "sync_pan_and_zoom"
+export const STOP_UPDATES_WHEN_FOCUS_IS_LOST = "stop_updates_when_focus_is_lost"
+export const DESTROY_ON_HIDE = "destroy_on_hide"
 
 /* eslint-disable camelcase */
 
 export interface Options {
   // performance options
-  stop_updates_when_focus_is_lost: boolean
+  [STOP_UPDATES_WHEN_FOCUS_IS_LOST]: boolean
   eliminate_zero_dimensions: boolean
-  destroy_on_hide: boolean
+  [DESTROY_ON_HIDE]: boolean
   async_on_scroll: boolean
 
   // synchronization options
@@ -40,11 +42,11 @@ export const INITIAL_OPTIONS: Options = {
   // performance options
 
   // boolean - shall we stop auto-refreshes when document does not have user focus
-  stop_updates_when_focus_is_lost: true,
+  [STOP_UPDATES_WHEN_FOCUS_IS_LOST]: true,
   // do not show dimensions with just zeros
   eliminate_zero_dimensions: true,
   // destroy charts when they are not visible
-  destroy_on_hide: false, // eventually apply slow device detection
+  [DESTROY_ON_HIDE]: false, // eventually apply slow device detection
   async_on_scroll: false,
 
   // synchronization options

--- a/src/index-npm.ts
+++ b/src/index-npm.ts
@@ -33,6 +33,10 @@ export { ChartContainer } from "domains/chart/components/chart-container"
 
 export { NodeView } from "domains/dashboard/components/node-view"
 
-export { resetGlobalPanAndZoomAction, setGlobalPanAndZoomAction } from "domains/global/actions"
+export {
+  resetGlobalPanAndZoomAction, setGlobalPanAndZoomAction, setOptionAction,
+} from "domains/global/actions"
+export { selectStopUpdatesWhenFocusIsLost, selectDestroyOnHide } from "domains/global/selectors"
+export { STOP_UPDATES_WHEN_FOCUS_IS_LOST, DESTROY_ON_HIDE } from "domains/global/options"
 
 export { VersionControl } from "components/app-header/components/version-control"


### PR DESCRIPTION
fixes:
- after sidebar toggle, resize dygraph (separate condition, because dygraph auto-resize on window width change, but don't detect other changes)
- prevent making new calls when previous for the chart are already in progress