### PR TITLE
misc-fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,7 +141,11 @@ const App: React.FC = () => {
 
   return (
     <ThemeProvider theme={DefaultTheme}>
-      <NotificationsContainer />
+      {hasFetchDependencies && (
+        // this needs to render after dynamic css files are loaded, otherwise netdata-ui
+        // styling will have smaller priority than bootstrap css
+        <NotificationsContainer />
+      )}
       {chartsMetadata && cloudBaseURL && hasFetchedInfo && (
         <>
           {!isPrintMode && (

--- a/src/components/app-header/styled.ts
+++ b/src/components/app-header/styled.ts
@@ -83,6 +83,7 @@ export const IconContainer = styled.div`
   margin: 0 5px;
 `
 export const IframeContainer = styled.div`
+  position: relative;
   width: 84px;
   height: 40px;
 `
@@ -121,3 +122,10 @@ export const SignInButton = styled.a<{ isDisabled: boolean }>`
 `
 
 export const OfflineBlock = styled.div``
+
+export const SignInIframe = styled.iframe<{ isShown: boolean }>`
+  position: absolute;
+  right: 0;
+  border: none;
+  display: ${({ isShown }) => (isShown ? undefined : "none")};
+`

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -815,8 +815,11 @@ export const DygraphChart = ({
     if (dygraphInstance.current) {
       // dygraph always resizes on browser width change, but doesn't resize when the container
       // has different width.
-      // @ts-ignore
-      dygraphInstance.current.resize()
+      window.requestAnimationFrame(() => {
+        if (dygraphInstance.current) {
+          (dygraphInstance.current as NetdataDygraph).resize()
+        }
+      })
     }
   }, [spacePanelTransitionEndIsActive])
 

--- a/src/utils/post-message.ts
+++ b/src/utils/post-message.ts
@@ -3,7 +3,7 @@ import { useEffect, useCallback, useState } from "react"
 type IframesMessageType = "spaces" | "workspaces"
   | "hello-from-spaces-bar" | "hello-from-space-panel" | "hello-from-sign-in"
   | "is-signed-in" | "streamed-hosts-data" | "has-focus" | "iframe-focus-change"
-  | "synced-private-registry"
+  | "synced-private-registry" | "set-is-logout-dropdown-opened"
 
 interface IframesMessage<T = unknown> {
   type: IframesMessageType
@@ -22,9 +22,9 @@ export const sendToChildIframe = (
 export const useListenToPostMessage = <T>(
   messageType: IframesMessageType,
   callback?: (newMessage: T) => void,
-  defaultState?: T,
-) => {
-  const [lastMessage, setLastMessage] = useState<T>(defaultState as T)
+  defaultState?: T | (() => T),
+): [T | undefined, () => void] => {
+  const [lastMessage, setLastMessage] = useState<T | undefined>(defaultState)
   const handleMessage = useCallback((message) => {
     const data = message.data as IframesMessage<T>
     if (data.type === messageType) {


### PR DESCRIPTION
- fix navbar icons (unnecessary paddings, a result of race condition between bootstrap.css and styled-components)
- safer time when resizing dygraph after toggling sidebar (additional RAF)
- leave door open for logout dropdown (allow setting width/height from iframe, which need more space sometimes, when dropdown is opened)