### PR TITLE
bytes-conversion

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -792,12 +792,26 @@ NETDATA.unitsConversion = {
             'gigabits/s': 1000000,
             'terabits/s': 1000000000
         },
+        'bytes/s': {
+            'bytes/s': 1,
+            'kilobytes/s': 1024,
+            'megabytes/s': 1024 * 1024,
+            'gigabytes/s': 1024 * 1024 * 1024,
+            'terabytes/s': 1024 * 1024 * 1024 * 1024
+        },
         'kilobytes/s': {
             'bytes/s': 1 / 1024,
             'kilobytes/s': 1,
             'megabytes/s': 1024,
             'gigabytes/s': 1024 * 1024,
             'terabytes/s': 1024 * 1024 * 1024
+        },
+        'B/s': {
+            'B/s': 1,
+            'KiB/s': 1024,
+            'MiB/s': 1024 * 1024,
+            'GiB/s': 1024 * 1024 * 1024,
+            'TiB/s': 1024 * 1024 * 1024 * 1024
         },
         'KB/s': {
             'B/s': 1 / 1024,

--- a/src/utils/units-conversion.ts
+++ b/src/utils/units-conversion.ts
@@ -29,12 +29,26 @@ const scalableUnits: ScalableUnits = {
     "gigabits/s": 1000000,
     "terabits/s": 1000000000,
   },
+  "bytes/s": {
+    "bytes/s": 1,
+    "kilobytes/s": 1024,
+    "megabytes/s": 1024 * 1024,
+    "gigabytes/s": 1024 * 1024 * 1024,
+    "terabytes/s": 1024 * 1024 * 1024 * 1024,
+  },
   "kilobytes/s": {
     "bytes/s": 1 / 1024,
     "kilobytes/s": 1,
     "megabytes/s": 1024,
     "gigabytes/s": 1024 * 1024,
     "terabytes/s": 1024 * 1024 * 1024,
+  },
+  "B/s": {
+    "B/s": 1,
+    "KiB/s": 1024,
+    "MiB/s": 1024 * 1024,
+    "GiB/s": 1024 * 1024 * 1024,
+    "TiB/s": 1024 * 1024 * 1024 * 1024,
   },
   "KB/s": {
     "B/s": 1 / 1024,


### PR DESCRIPTION
fixes https://github.com/netdata/dashboard/issues/88

We need that last units-conversion fix in the new Netdata release, but the dashboard is too far ahead, so i created a branch off last commit from https://github.com/netdata/dashboard/releases/tag/v1.0.14 and added the bytes-conversion change. Other changes are not tested enough to go to that release