### PR TITLE
few tweaks needed by custom dashboards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/components/chart-container/chart-container.tsx
+++ b/src/domains/chart/components/chart-container/chart-container.tsx
@@ -12,7 +12,7 @@ export type Props = {
   // here, the chartID must be unique across all agents
   chartUuid: string
   portalNode: HTMLElement
-  chartMetadata?: ChartMetadata
+  chartMetadata?: ChartMetadata | undefined
   dropdownMenu?: DropdownMenu
 }
 

--- a/src/domains/chart/components/chart-dropdown/chart-dropdown.tsx
+++ b/src/domains/chart/components/chart-dropdown/chart-dropdown.tsx
@@ -1,23 +1,36 @@
 import React, { useState, ReactNode } from "react"
 
+import { Attributes } from "domains/chart/utils/transformDataAttributes"
+import { ChartMetadata } from "domains/chart/chart-types"
+
 import { List, SimpleListItem } from "@rmwc/list"
 import { MenuSurface, MenuSurfaceAnchor } from "@rmwc/menu"
 
 import * as S from "./styled"
 
+interface DropdownMenuCallbackProps {
+  attributes: Attributes,
+  chartMetadata: ChartMetadata,
+  chartID: string,
+}
+
 export type DropdownMenu = {
   icon: ReactNode,
   label: string,
-  onClick: (chartID: string) => void,
+  onClick: (dropdownMenuCallbackProps: DropdownMenuCallbackProps) => void,
 }[]
 
 interface Props {
+  attributes: Attributes
   chartID: string
+  chartMetadata: ChartMetadata
   dropdownMenu: DropdownMenu
 }
 
 export const ChartDropdown = ({
+  attributes,
   chartID,
+  chartMetadata,
   dropdownMenu,
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false)
@@ -49,7 +62,7 @@ export const ChartDropdown = ({
                   </S.DropdownItem>
                 )}
                 onClick={() => {
-                  onClick(chartID)
+                  onClick({ attributes, chartMetadata, chartID })
                   handleClose()
                 }}
               />

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -313,7 +313,12 @@ export const ChartWithLoader = ({
       />
       {dropdownMenu && (dropdownMenu.length > 0) && (
         <S.ChartDropdownContainer>
-          <ChartDropdown dropdownMenu={dropdownMenu} chartID={attributes.id} />
+          <ChartDropdown
+            dropdownMenu={dropdownMenu}
+            chartID={attributes.id}
+            attributes={attributes}
+            chartMetadata={actualChartMetadata}
+          />
         </S.ChartDropdownContainer>
       )}
     </>

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -233,7 +233,9 @@ function* fetchChartSaga({ payload }: Action<FetchChartPayload>) {
   }
 
   let response
-  const url = `${alwaysEndWithSlash(host)}api/v1/chart`
+  const url = isMainJs
+    ? `${alwaysEndWithSlash(host)}api/v1/chart`
+    : host.replace("/data", "/chart")
   try {
     response = yield call(axiosInstance.get, url, {
       params: {

--- a/src/index-npm.ts
+++ b/src/index-npm.ts
@@ -15,12 +15,7 @@ import "./styles/bootstrap-3.3.7.css"
 
 import "vendor/fontawesome-all-5.0.1.min"
 
-// Cannot re-export a type when the --isolatedModules flag is provided
-import { Attributes } from "domains/chart/utils/transformDataAttributes"
-
 window.Ps = Ps
-
-export type ChartAttributes = Attributes
 
 export {
   dashboardReduxContext,
@@ -40,3 +35,17 @@ export { selectStopUpdatesWhenFocusIsLost, selectDestroyOnHide } from "domains/g
 export { STOP_UPDATES_WHEN_FOCUS_IS_LOST, DESTROY_ON_HIDE } from "domains/global/options"
 
 export { VersionControl } from "components/app-header/components/version-control"
+
+/**
+ types
+**/
+
+// Cannot re-export a type when the --isolatedModules flag is provided
+import { Attributes } from "domains/chart/utils/transformDataAttributes"
+export type ChartAttributes = Attributes
+
+import { ChartMetadata as ChartMetadata_ } from "domains/chart/chart-types"
+export type ChartMetadata = ChartMetadata_
+
+import { ChartsMetadata as ChartsMetadata_ } from "domains/global/types"
+export type ChartsMetadata = ChartsMetadata_

--- a/src/index-npm.ts
+++ b/src/index-npm.ts
@@ -37,9 +37,10 @@ export { STOP_UPDATES_WHEN_FOCUS_IS_LOST, DESTROY_ON_HIDE } from "domains/global
 export { VersionControl } from "components/app-header/components/version-control"
 
 /**
- types
-**/
+ * types
+ */
 
+/* eslint-disable import/first,import/newline-after-import */
 // Cannot re-export a type when the --isolatedModules flag is provided
 import { Attributes } from "domains/chart/utils/transformDataAttributes"
 export type ChartAttributes = Attributes
@@ -49,3 +50,4 @@ export type ChartMetadata = ChartMetadata_
 
 import { ChartsMetadata as ChartsMetadata_ } from "domains/global/types"
 export type ChartsMetadata = ChartsMetadata_
+/* eslint-enable import/first,import/newline-after-import */


### PR DESCRIPTION
- pass attributes and metadata to dropdown callback (needed by custom-dashboards)
- support fetching metadata from ACLK directly by charts
- add few more exports (types) so we can import them from single index-npm.ts file