### PR TITLE
fake-stacked chart type

### DIFF
--- a/dashboard-react.js
+++ b/dashboard-react.js
@@ -206,6 +206,7 @@ NETDATA.options = {
 
     color_fill_opacity_line: 1.0,
     color_fill_opacity_area: 0.2,
+    color_fill_opacity_fake_stacked: 1,
     color_fill_opacity_stacked: 0.8,
 
     pan_and_zoom_factor: 0.25,      // the increment when panning and zooming with the toolbox

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2137,6 +2137,30 @@
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.9.tgz",
       "integrity": "sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==",
+      "dev": true
+    },
+    "@types/color": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.1.tgz",
+      "integrity": "sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==",
+      "dev": true,
+      "requires": {
+        "@types/color-convert": "*"
+      }
+    },
+    "@types/color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "*"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "@types/d3": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [
@@ -28,6 +28,7 @@
     "bootstrap-toggle": "~2.2.2",
     "classnames": "^2.2.6",
     "clipboard-polyfill": "^2.8.6",
+    "color": "^3.1.2",
     "d3": "4.12.2",
     "dygraphs": "2.1.0",
     "easy-pie-chart": "^2.1.7",
@@ -63,6 +64,7 @@
     "@testing-library/react": "^9.2.0",
     "@types/bootstrap": "^3",
     "@types/classnames": "^2.2.9",
+    "@types/color": "^3.0.1",
     "@types/d3": "^4.11.0",
     "@types/dygraphs": "^1.1.8",
     "@types/enzyme": "^3.10.3",

--- a/src/domains/chart/components/lib-charts/dygraph/utils.ts
+++ b/src/domains/chart/components/lib-charts/dygraph/utils.ts
@@ -1,3 +1,7 @@
+/* eslint-disable no-nested-ternary */
+import { always, memoizeWith } from "ramda"
+import Color from "color"
+
 import { ChartMetadata, DygraphData } from "domains/chart/chart-types"
 import { Attributes } from "domains/chart/utils/transformDataAttributes"
 import { ChartLibraryConfig } from "domains/chart/utils/chartLibrariesSettings"
@@ -51,3 +55,22 @@ export const getDygraphChartType = (
   }
   return dygraphChartType
 }
+
+const getBackgroundColor = memoizeWith(
+  always("true"),
+  () => Color(window.NETDATA.themes.current.background),
+)
+// when in "fakeStacked" mode, we cannot use opacity for fill in charts, because the areas would
+// be visible under each other. So the darkening / whitening needs to be added directly to colors
+// (the colors are too saturated for areas and in stacked mode they were with 0.8 opacity)
+export const transformColors = (colors: string[]) => (
+  colors.map((color) => Color(color).mix(getBackgroundColor(), 0.2).hex())
+)
+
+export const getDygraphFillAlpha = (
+  isFakeStacked: boolean, dygraphChartType: string,
+) => (isFakeStacked
+  ? window.NETDATA.options.current.color_fill_opacity_fake_stacked
+  : dygraphChartType === "stacked"
+    ? window.NETDATA.options.current.color_fill_opacity_stacked
+    : window.NETDATA.options.current.color_fill_opacity_area)

--- a/src/domains/chart/components/lib-charts/dygraph/utils.ts
+++ b/src/domains/chart/components/lib-charts/dygraph/utils.ts
@@ -1,0 +1,53 @@
+import { ChartMetadata, DygraphData } from "domains/chart/chart-types"
+import { Attributes } from "domains/chart/utils/transformDataAttributes"
+import { ChartLibraryConfig } from "domains/chart/utils/chartLibrariesSettings"
+
+export const getDataForFakeStacked = (
+  data: number[][],
+  dimensionsVisibility: boolean[],
+): number[][] => data.map((point) => {
+  const [timestamp, ...values] = point
+  const rest: number[] = []
+  let currentMin = 0
+  let currentMax = 0
+  values
+    .map((value, i) => ({ isVisible: dimensionsVisibility[i], value }))
+    // reverse because first dimensions should be "on top" (at least positive ones)
+    .slice().reverse()
+    .forEach(({ isVisible, value }) => {
+      if (!isVisible) {
+        rest.push(0) // push with value '0'. it won't be visible but needs to be present in array
+        return
+      }
+      if (value >= 0) {
+        currentMax += value
+        rest.push(currentMax)
+      } else {
+        currentMin += value
+        rest.push(currentMin)
+      }
+    })
+  return [
+    timestamp,
+    ...rest,
+  ]
+})
+
+export const getDygraphChartType = (
+  attributes: Attributes, chartData: DygraphData, chartMetadata: ChartMetadata,
+  chartSettings: ChartLibraryConfig,
+) => {
+  const isLogScale = (chartSettings.isLogScale as ((a: Attributes) => boolean))(attributes)
+  const {
+    dygraphType: dygraphRequestedType = chartMetadata.chart_type,
+  } = attributes
+  // corresponds to state.tmp.dygraph_chart_type in old app
+  let dygraphChartType = dygraphRequestedType
+  if (dygraphChartType === "stacked" && chartData.dimensions === 1) {
+    dygraphChartType = "area"
+  }
+  if (dygraphChartType === "stacked" && isLogScale) {
+    dygraphChartType = "area"
+  }
+  return dygraphChartType
+}

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -95,6 +95,7 @@ interface NETDATA {
       color_fill_opacity_line: number
       color_fill_opacity_area: number
       color_fill_opacity_stacked: number
+      color_fill_opacity_fake_stacked: number
 
       pan_and_zoom_factor: number
       pan_and_zoom_factor_multiplier_control: number


### PR DESCRIPTION
fixes https://github.com/netdata/netdata/issues/9663
Stacked charts with negative values were not supported by dygraph.js, so i've built a hack around how dygraph.js works - for such charts, whenever negative value appears in stacked chart, FE now sums the values manually