### PR TITLE
y-axis and scaling for constant values fix

### DIFF
--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -3,7 +3,9 @@ import React, {
   useLayoutEffect, useRef, useCallback,
 } from "react"
 import { useUpdateEffect, useUnmount, useMount } from "react-use"
-import Dygraph from "dygraphs"
+// this version is needed because it contains a fix for handling constant value in the chart
+// ie. https://github.com/danvk/dygraphs/pull/909
+import Dygraph from "vendor/dygraph-c91c859.min"
 import "dygraphs/src-es5/extras/smooth-plotter"
 import ResizeObserver from "resize-observer-polyfill"
 

--- a/src/vendor/dygraph-c91c859.min.js
+++ b/src/vendor/dygraph-c91c859.min.js
@@ -1,0 +1,1 @@
+../../public/lib/dygraph-c91c859.min.js


### PR DESCRIPTION
change dygraph version to the same which was used in old dashboard. That version had a fix from @ktsaou for constant other than 0. In those cases no y-legend was present and autoscaling was broken.

Instead of uploading full js file to the repo, i linked already existing file in /public, which normally is used for hosting old dashboard in the Agent. I checked that `npm run build` works fine and fixes similar problem when added to cloud-fe.

related issue: https://github.com/netdata/netdata/issues/9659

old issue explaining the problem: https://github.com/netdata/netdata/pull/3407