### PR TITLE
fill fake nulls when requesting more than available history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/actions.ts
+++ b/src/domains/chart/actions.ts
@@ -23,6 +23,7 @@ export const updateChartMetadataAction = createAction<UpdateChartMetadataAction>
 )
 
 export interface FetchDataParams {
+  fillMissingPoints?: number
   isRemotelyControlled: boolean
   viewRange: [number, number]
 }

--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -295,11 +295,17 @@ export const Chart = memo(({
   }, [handleToolBoxPanAndZoom, netdataLast, viewAfter, viewBefore])
 
   const handleToolboxZoomInClick = useCallback((event: React.MouseEvent) => {
+    // if visible time range is much bigger than available time range in history, first zoom-in
+    // should just fit to available range
+    if ((viewBefore - viewAfter) > (netdataLast - netdataFirst) * 1.2) {
+      handleToolBoxPanAndZoom(netdataFirst, netdataLast)
+      return
+    }
     const dt = ((viewBefore - viewAfter) * getPanAndZoomStep(event) * 0.8) / 2
     const newAfter = viewAfter + dt
     const newBefore = viewBefore - dt
     handleToolBoxPanAndZoom(newAfter, newBefore)
-  }, [handleToolBoxPanAndZoom, viewAfter, viewBefore])
+  }, [handleToolBoxPanAndZoom, netdataFirst, netdataLast, viewAfter, viewBefore])
 
   const handleToolboxZoomOutClick = useCallback((event: React.MouseEvent) => {
     const dt = ((viewBefore - viewAfter) / (1.0 - (getPanAndZoomStep(event) * 0.8))

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -14,6 +14,7 @@ import { axiosInstance } from "utils/api"
 import { alwaysEndWithSlash, serverDefault } from "utils/server-detection"
 import { getFetchStream } from "utils/netdata-sdk"
 import { isMainJs } from "utils/env"
+import { fillMissingData } from "utils/fill-missing-data"
 
 import {
   showCloudInstallationProblemNotification, showCloudConnectionProblemNotification,
@@ -35,6 +36,7 @@ import {
   FetchInfoPayload,
   fetchDataCancelAction,
 } from "./actions"
+import { ChartData } from "./chart-types"
 
 const CONCURRENT_CALLS_LIMIT_METRICS = isMainJs ? 30 : 60
 const CONCURRENT_CALLS_LIMIT_PRINT = 2
@@ -134,8 +136,9 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
   }
 
   const onSuccessCallback = (data: unknown) => {
+    const { fillMissingPoints } = fetchDataParams
     fetchDataResponseChannel.put(fetchDataAction.success({
-      chartData: data,
+      chartData: fillMissingPoints ? fillMissingData(data as ChartData, fillMissingPoints) : data,
       fetchDataParams,
       id,
     }))

--- a/src/domains/dashboard/components/head-main.tsx
+++ b/src/domains/dashboard/components/head-main.tsx
@@ -18,6 +18,7 @@ export const HeadMain = ({
   const commonAttributes = {
     host,
     after: -duration,
+    forceTimeWindow: true,
     points: duration,
   }
 

--- a/src/domains/dashboard/components/node-view/node-view.tsx
+++ b/src/domains/dashboard/components/node-view/node-view.tsx
@@ -74,6 +74,7 @@ const SubSection = memo(({
                 attributes={
                   {
                     ...attributes,
+                    forceTimeWindow: true, // respect timeWindow
                     host,
                     ...(attributesOverrides ? attributesOverrides[attributes.id] : {}),
                   }

--- a/src/domains/dashboard/components/node-view/render-submenu-name.tsx
+++ b/src/domains/dashboard/components/node-view/render-submenu-name.tsx
@@ -126,6 +126,7 @@ export const renderSubmenuName = ({
                 decimalDigits: netdataDashboard.contextDecimalDigits(
                   chart.context, -1,
                 ),
+                forceTimeWindow: true,
                 // add commonMin/commonMax attributes only if they are set
                 ...(commonMin ? { commonMin } : {}),
                 ...(commonMax ? { commonMax } : {}),

--- a/src/utils/fill-missing-data.test.ts
+++ b/src/utils/fill-missing-data.test.ts
@@ -1,0 +1,72 @@
+import { DygraphData } from "domains/chart/chart-types"
+import { addPointsDygraph } from "./fill-missing-data"
+
+const dygraphData = {
+  after: 1600000221,
+  view_update_every: 1,
+  result: {
+    data: [
+      [1600000222, 100],
+      [1600000223, 100],
+      [1600000224, 100],
+    ],
+    labels: ["time", "dimension1"],
+  },
+}
+
+const dygraphDataMultipleDimensions = {
+  after: 1600000221,
+  view_update_every: 1,
+  result: {
+    data: [
+      [1600000222, 100, 100, 100],
+      [1600000223, 100, 100, 100],
+      [1600000224, 100, 100, 100],
+    ],
+    labels: ["time", "dimension1", "dimension2", "dimension3"],
+  },
+}
+
+const dygraphDataEmpty = {
+  after: 1600000221,
+  view_update_every: 3,
+  result: {
+    data: ([] as number[][]),
+    labels: ["time", "no data"],
+  },
+}
+
+describe("fill missing data", () => {
+  describe("addPointsDygraph", () => {
+    it("fill nulls with proper timestamps", () => {
+      const output = addPointsDygraph(dygraphData as DygraphData, 3)
+      expect(output.result.data).toStrictEqual([
+        [1600000219, null],
+        [1600000220, null],
+        [1600000221, null],
+        [1600000222, 100],
+        [1600000223, 100],
+        [1600000224, 100],
+      ])
+    })
+    it("fill proper nr of nulls (respect dimension numbers)", () => {
+      const output = addPointsDygraph(dygraphDataMultipleDimensions as DygraphData, 3)
+      expect(output.result.data).toStrictEqual([
+        [1600000219, null, null, null],
+        [1600000220, null, null, null],
+        [1600000221, null, null, null],
+        [1600000222, 100, 100, 100],
+        [1600000223, 100, 100, 100],
+        [1600000224, 100, 100, 100],
+      ])
+    })
+    it("after param is updated accordingly", () => {
+      const output = addPointsDygraph(dygraphDataMultipleDimensions as DygraphData, 3)
+      expect(output.after).toBe(dygraphDataMultipleDimensions.after - 3)
+    })
+    it("returns the same object when there's no data at all", () => {
+      const output = addPointsDygraph(dygraphDataEmpty as DygraphData, 3)
+      expect(output).toBe(dygraphDataEmpty)
+    })
+  })
+})

--- a/src/utils/fill-missing-data.ts
+++ b/src/utils/fill-missing-data.ts
@@ -1,0 +1,62 @@
+import { tail } from "ramda"
+import { ChartData, DygraphData } from "domains/chart/chart-types"
+
+/*
+when requesting for bigger time interval than available history in the agent,
+we get only the available range. Dashboard was first designed to not allow zooming-out too much.
+But we want to show the requested time-range, so to do it consistently, we return nr of points
+when making the request, and after getting result, we add `null`s at the beginning
+ */
+
+interface GetCorrectedPointsArg {
+  after: number
+  before: number
+  firstEntry: number
+  points: number
+}
+export const getCorrectedPoints = ({
+  after,
+  before,
+  firstEntry,
+  points,
+}: GetCorrectedPointsArg) => {
+  const nowInSeconds = Math.round(new Date().valueOf() / 1000)
+  const afterAbsolute = after > 0 ? after : (nowInSeconds + after)
+  const beforeAbsolute = before > 0 ? before : (nowInSeconds + before)
+
+  if (afterAbsolute < firstEntry) {
+    // take into account first_entry
+    const realAfter = Math.max(afterAbsolute, firstEntry)
+    const requestedRange = beforeAbsolute - afterAbsolute
+    const availableRange = beforeAbsolute - realAfter
+
+    return Math.round((points * availableRange) / requestedRange)
+  }
+  return null
+}
+
+export const addPointsDygraph = (data: DygraphData, nrOfPointsToFill: number) => {
+  const viewUpdateEvery = data.view_update_every
+  if (!data.result.data.length) {
+    return data
+  }
+  const firstAddedTimestamp = data.result.data[0][0] - nrOfPointsToFill * viewUpdateEvery
+  const emptyPoint = tail(data.result.labels).map(() => null)
+  const nulls = new Array(nrOfPointsToFill).fill(null)
+    .map((_, i) => ([firstAddedTimestamp + i * viewUpdateEvery, ...emptyPoint]))
+  return {
+    ...data,
+    after: data.after - viewUpdateEvery * nrOfPointsToFill,
+    result: {
+      ...data.result,
+      data: nulls.concat(data.result.data),
+    },
+  }
+}
+
+export const fillMissingData = (data: ChartData, nrOfPointsToFill: number) => {
+  if (data.format === "json") {
+    return addPointsDygraph(data as DygraphData, nrOfPointsToFill)
+  }
+  return data
+}


### PR DESCRIPTION
When requesting for bigger time interval than available history in the agent, we get only the available range. Dashboard was first designed to not allow zooming-out too much, so when we were requesting too big range, we were getting in response the same nr of points requested, but in smaller time frame (for available history). We want to force the requested time frame, so that bigger frequency is a waste, and instead we'll now request reduced nr of points, and after getting response, we'll fill empty data, so that charts have requested time-frame on x-axes.
