### PR TITLE
Remove ref from chart data

### DIFF
--- a/copy-assets.js
+++ b/copy-assets.js
@@ -7,4 +7,5 @@ cpx.copy("src/styles/*", "lib/src/styles", {})
 cpx.copy("src/**/*.css", "lib/src", {})
 cpx.copy("src/**/*.scss", "lib/src", {})
 
+cpx.copy("src/**/*.gif", "lib/src", {})
 cpx.copy("src/**/*.svg", "lib/src", {})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -1,7 +1,7 @@
 import { cond, always, T } from "ramda"
 import axios from "axios"
 import React, {
-  useEffect, useState, useMemo, useRef,
+  useEffect, useState, useMemo,
 } from "react"
 import {
   useThrottle, useUpdateEffect, useUnmount, useDebounce,
@@ -339,16 +339,13 @@ export const ChartWithLoader = ({
     }
   }, [externalSelectedDimensions])
 
-  const chartDataRef = useRef<ChartData | null>(null)
-  chartDataRef.current = chartData
-
   const customElementForDygraph = useMemo(
     () => renderCustomElementForDygraph && renderCustomElementForDygraph({
       attributes,
       chartMetadata: actualChartMetadata as ChartMetadata,
       chartID: id,
-      getChartData: () => chartDataRef.current,
-    }), [renderCustomElementForDygraph, attributes, id, actualChartMetadata],
+      getChartData: () => chartData,
+    }), [renderCustomElementForDygraph, attributes, id, actualChartMetadata, chartData],
   )
 
   // eslint-disable-next-line max-len


### PR DESCRIPTION
Fixed inconsistency in nodes length between rerenders.
Fyi: As discussed with @jacekkolasa we are going to keep our eye on this, to check if there are any perf issues. The next step is to expose a dashboard selector that we can use from the parent component (in this case cloud) (Thanks @jacekkolasa )