### PR TITLE
styling fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/components/chart-legend-bottom.styled.ts
+++ b/src/domains/chart/components/chart-legend-bottom.styled.ts
@@ -18,7 +18,6 @@ export const LegendSecondRow = styled.div`
 `
 
 export const LegendUnit = styled.div`
-  margin-top: 4px;
   color: ${getColor("textFocus")};
 `
 

--- a/src/domains/chart/components/chart-legend-bottom.styled.ts
+++ b/src/domains/chart/components/chart-legend-bottom.styled.ts
@@ -37,6 +37,10 @@ export const DimensionItem = styled.div<{ color: string, isDisabled: boolean }>`
   margin-right: ${getSizeBy(2)};
   cursor: pointer;
   opacity: ${({ isDisabled }) => (isDisabled ? 0.3 : null)};
+  user-select: none;
+  &:focus {
+    outline: none;
+  }
 `
 
 export const DimensionIcon = styled.div<{ color: string }>`

--- a/src/domains/chart/components/chart-spinner/chart-spinner.tsx
+++ b/src/domains/chart/components/chart-spinner/chart-spinner.tsx
@@ -2,27 +2,38 @@ import React from "react"
 
 import * as S from "./styled"
 
-// @ts-ignore
-import chartLoadingSpinner from "./chart-loading-spinner-ver3.gif"
-
-// temporary measure, to test spinner in form of a gif
-const isGifSpinner = Boolean(localStorage.getItem("gif-spinner"))
-
 interface Props {
   chartLibrary: string
 }
 export const ChartSpinner = ({
   chartLibrary,
 }: Props) => {
-  const margin = chartLibrary === "dygraph" ? 4 : 0
-  if (isGifSpinner) {
-    return (
-      <S.GifSpinnerContainer className="GifSpinnerContainer" margin={margin}>
-        <img src={chartLoadingSpinner} alt="spinner" />
-      </S.GifSpinnerContainer>
-    )
-  }
+  const top = chartLibrary === "dygraph" ? 30 : 0
+  const right = chartLibrary === "dygraph" ? 10 : 0
   return (
-    <S.ChartSpinner margin={margin} />
+    <S.GifSpinnerContainer style={{ width: "10px", height: "10px" }} top={top} right={right}>
+      <svg
+        shapeRendering="geometricPrecision"
+        textRendering="geometricPrecision"
+        viewBox="0 0 20 20"
+        transform="translate(0,-5)"
+      >
+        <g transform="translate(10,9) translate(-8,-9)">
+          <S.SvgCircle
+            // eslint-disable-next-line max-len
+            d="M16.312,5.103L17.137,4.278C17.528,3.887,17.528,3.255,17.137,2.864C16.746,2.473,16.114,2.473,15.723,2.864L14.898,3.689C13.792,2.829,12.458,2.253,11,2.07L11,2C11.553,2,12,1.552,12,1C12,0.448,11.553,0,11,0L9,0C8.447,0,8,0.448,8,1C8,1.552,8.447,2,9,2L9,2.069C7.542,2.252,6.208,2.828,5.102,3.688L4.277,2.863C3.886,2.472,3.254,2.472,2.863,2.863C2.472,3.254,2.472,3.886,2.863,4.277L3.688,5.102C2.634,6.458,2,8.154,2,10C2,14.411,5.589,18,10,18C14.411,18,18,14.411,18,10C18,8.154,17.366,6.458,16.312,5.103ZM10,16C6.691,16,4,13.309,4,10C4,6.691,6.691,4,10,4C13.309,4,16,6.691,16,10C16,13.309,13.309,16,10,16Z"
+            transform="translate(8,9) translate(-10,-9)"
+          />
+        </g>
+        <S.SvgSpinner transform="translate(10,10) translate(-10,-10)">
+          <ellipse opacity="0" fill="#93A3B0" rx="7" ry="7" transform="translate(10,10)" />
+          <S.SvgSpinnerPath
+            // eslint-disable-next-line max-len
+            d="M10,11C9.447,11,9,10.552,9,10L9,6C9,5.448,9.447,5,10,5C10.553,5,11,5.448,11,6L11,10C11,10.552,10.553,11,10,11Z"
+            transform="translate(10,8) translate(-10,-8)"
+          />
+        </S.SvgSpinner>
+      </svg>
+    </S.GifSpinnerContainer>
   )
 }

--- a/src/domains/chart/components/chart-spinner/styled.ts
+++ b/src/domains/chart/components/chart-spinner/styled.ts
@@ -3,46 +3,30 @@ import styled, { keyframes } from "styled-components"
 
 import { getColor } from "@netdata/netdata-ui"
 
-const spinnerAnimation = keyframes`
-  to {
-    transform: rotate(360deg);
+const svgSpinnerAnimation = keyframes`
+  0% {
+   transform: translate(10px,10px) rotate(0deg) translate(-10px,-10px);
+  }
+  100% {
+   transform: translate(10px,10px) rotate(350deg) translate(-10px,-10px);
   }
 `
 
-export const GifSpinnerContainer = styled.div<{ margin: number }>`
+export const GifSpinnerContainer = styled.div<{ top: number, right: number }>`
   position: absolute;
-  top: ${prop("margin")}px;
-  right: ${prop("margin")}px;
+  top: ${prop("top")}px;
+  right: ${prop("right")}px;
+  opacity: .5;
 `
 
-const clockRadius = 8
-const clockLine = 1
-const clockColor = "border"
+export const SvgSpinner = styled.g`
+  animation: 1s linear infinite both ${svgSpinnerAnimation};
+`
 
+export const SvgSpinnerPath = styled.path`
+  fill: ${getColor("border")};
+`
 
-export const ChartSpinner = styled.div<{ margin: number }>`
-  position: absolute;
-  top: ${prop("margin")}px;
-  right: ${prop("margin")}px;
-  
-  width: ${clockRadius * 2}px;
-  height: ${clockRadius * 2}px;
-  background-color: rgba(0, 0, 0, 0);
-  box-shadow: inset 0 0 0 ${clockLine}px ${getColor(clockColor)};
-  border-radius: 50%;
-  
-  &:after {
-    position: absolute;
-    content: "";
-    transform-origin: ${clockLine / 2}px ${clockLine / 2}px;
-    background-color: ${getColor(clockColor)};
-    height: ${clockLine}px;
-    top: ${clockRadius - clockLine / 2}px;
-    left: ${clockRadius - clockLine / 2}px;
-  }
-  
-  &:after {
-    width: ${clockRadius * (5 / 6)}px;
-    animation: ${spinnerAnimation} 0.6s linear infinite;
-  }
+export const SvgCircle = styled.path`
+  fill: ${getColor("border")};
 `

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -2,6 +2,7 @@ import { sortBy, reverse } from "ramda"
 import React, {
   useLayoutEffect, useRef, useCallback,
 } from "react"
+import classNames from "classnames"
 import { useUpdateEffect, useUnmount, useMount } from "react-use"
 // this version is needed because it contains a fix for handling constant value in the chart
 // ie. https://github.com/danvk/dygraphs/pull/909
@@ -94,7 +95,9 @@ const getInitialDygraphOptions = ({
     dygraphSmooth = dygraphChartType === "line"
       && !isSparkline,
     dygraphDrawAxis = true,
+    legendPosition,
   } = attributes
+  const isLegendOnBottom = legendPosition === "bottom"
   const {
     // destructuring with default values
     dygraphColors = orderedColors,
@@ -151,7 +154,7 @@ const getInitialDygraphOptions = ({
     dygraphXAxisLabelWidth = 60,
     dygraphDrawXAxis = dygraphDrawAxis,
     dygraphYPixelsPerLabel = 15,
-    dygraphYAxisLabelWidth = 50,
+    dygraphYAxisLabelWidth = isLegendOnBottom ? 30 : 50,
     dygraphDrawYAxis = dygraphDrawAxis,
   } = attributes
   return {
@@ -177,8 +180,8 @@ const getInitialDygraphOptions = ({
     xRangePad: dygraphXRangePad,
     yRangePad: isSparkline ? 1 : dygraphYRangePad,
     valueRange: dygraphValueRange,
-    ylabel: isSparkline ? undefined : unitsCurrent,
-    yLabelWidth: isSparkline ? 0 : dygraphYLabelWidth,
+    ylabel: (isSparkline || isLegendOnBottom) ? undefined : unitsCurrent,
+    yLabelWidth: (isSparkline || isLegendOnBottom) ? 0 : dygraphYLabelWidth,
 
     // the function to plot the chart
     plotter: (dygraphSmooth && shouldSmoothPlot) ? window.smoothPlotter : null,
@@ -815,8 +818,9 @@ export const DygraphChart = ({
   useUpdateEffect(() => {
     if (dygraphInstance.current) {
       const isSparkline = attributes.dygraphTheme === "sparkline"
+      const isLegendOnBottom = attributes.legendPosition === "bottom"
       dygraphInstance.current.updateOptions({
-        ylabel: isSparkline ? undefined : unitsCurrent,
+        ylabel: (isSparkline || isLegendOnBottom) ? undefined : unitsCurrent,
       })
     }
   }, [attributes, unitsCurrent])
@@ -1030,12 +1034,17 @@ export const DygraphChart = ({
     }
   })
 
+  const isLegendOnBottom = attributes.legendPosition === "bottom"
+
   return (
     <>
       <div
         ref={chartElement}
         id={chartElementId}
-        className={chartElementClassName}
+        className={classNames(
+          chartElementClassName,
+          { "dygraph-chart--legend-bottom": isLegendOnBottom },
+        )}
       />
       <div className="dygraph-chart__labels-hidden" id={hiddenLabelsElementId} />
     </>

--- a/src/domains/dashboard/components/node-view/node-view.scss
+++ b/src/domains/dashboard/components/node-view/node-view.scss
@@ -57,6 +57,18 @@ $CLOUD_SECONDARY_HEADER_HEIGHT: 64px;
     & ul {
       padding-left: 0;
     }
+
+    .dashboard-section {
+      h1 {
+        margin-top: 20px;
+      }
+    }
+
+    .dashboard-section-container {
+      & > h2 {
+        margin-top: 20px;
+      }
+    }
   }
 
   &__sidebar-container {

--- a/src/domains/dashboard/components/node-view/node-view.scss
+++ b/src/domains/dashboard/components/node-view/node-view.scss
@@ -58,6 +58,10 @@ $CLOUD_SECONDARY_HEADER_HEIGHT: 64px;
       padding-left: 0;
     }
 
+    .dygraph-chart--legend-bottom .dygraph-axis-label-y {
+      text-align: start ;
+    }
+
     .dashboard-section {
       h1 {
         margin-top: 20px;

--- a/src/domains/dashboard/components/node-view/render-submenu-name.tsx
+++ b/src/domains/dashboard/components/node-view/render-submenu-name.tsx
@@ -71,12 +71,12 @@ export const renderSubmenuName = ({
       id={submenuID}
       key={submenuName}
     >
-      <h2 id={submenuID} className="netdata-chart-alignment">
+      <h2 id={submenuID}>
         {submenu.title}
       </h2>
       {submenuInfo && (
         <div
-          className="dashboard-submenu-info netdata-chart-alignment"
+          className="dashboard-submenu-info"
           role="document"
         >
           {submenuInfo}

--- a/src/domains/dashboard/utils/netdata-dashboard.ts
+++ b/src/domains/dashboard/utils/netdata-dashboard.ts
@@ -210,7 +210,7 @@ export const netdataDashboard = {
     const x = this.anyAttribute(this.context, "info", id, null)
 
     if (x !== null) {
-      return `<div class="shorten dashboard-context-info netdata-chart-alignment"
+      return `<div class="shorten dashboard-context-info"
         role="document">${x}</div>`
     }
     return ""

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -129,7 +129,6 @@ body {
     color: var(--color-placeholder, #DDDDDD);
     text-align: center;
     overflow: hidden;
-    z-index: 20;
     padding: 0px;
     margin: 0px;
 }
@@ -148,7 +147,6 @@ body {
     color: var(--color-placeholder, #DDDDDD);
     text-align: center;
     overflow: hidden;
-    z-index: 20;
     padding: 0px;
     margin: 0px;
 
@@ -171,7 +169,6 @@ body {
     color: var(--color-border, #CDCDCD);
     text-align: center;
     overflow: hidden;
-    z-index: 21;
     padding: 0px;
     margin: 0px;
     cursor: pointer;
@@ -389,7 +386,6 @@ body {
 .netdata-chart-with-legend-bottom {
     display: block;
     overflow: hidden;
-    z-index: 5;
     flex-grow: 1;
 }
 

--- a/src/styles/dashboard.slate.css
+++ b/src/styles/dashboard.slate.css
@@ -111,7 +111,7 @@ code {
 }
 
 .netdata-container-with-legend {
-    display: inline-block;
+    /*display: inline-block;*/
     overflow: hidden;
 
     transform: translate3d(0,0,0);
@@ -123,6 +123,9 @@ code {
     position: relative;
 
     /* width and height is given per chart with data-width and data-height */
+
+    display: flex;
+    flex-direction: column;
 }
 
 .netdata-legend-resize-handler {
@@ -140,7 +143,6 @@ code {
     color: #373b40;
     text-align: center;
     overflow: hidden;
-    z-index: 20;
     padding: 0px;
     margin: 0px;
 }
@@ -159,7 +161,6 @@ code {
     color: #373b40;
     text-align: center;
     overflow: hidden;
-    z-index: 20;
     padding: 0px;
     margin: 0px;
 
@@ -182,7 +183,6 @@ code {
     color: #474b50;
     text-align: center;
     overflow: hidden;
-    z-index: 21;
     padding: 0px;
     margin: 0px;
     cursor: pointer;
@@ -400,7 +400,6 @@ code {
 .netdata-chart-with-legend-bottom {
     display: block;
     overflow: hidden;
-    z-index: 5;
     flex-grow: 1;
 }
 


### PR DESCRIPTION
- new animated svg spinner
- clean z-indexes to fix cloud-dropdowns problems
- align node-view headers to the left
- add more horizontal space between node-view sections
- dygraph tweaks when legend is on the bottom - remove redundant units, smaller y-axis legend, align to left
- remove unnecessary effects when selecting bottom-legend dimensions