### PR TITLE
context production hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.0.1",
+  "version": "2.0.1-hotfix-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.0.1",
+  "version": "2.0.1-hotfix-1",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -133,9 +133,6 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
     after,
     before,
     dimensions,
-    context: chart,
-    ...(aggrMethod && { aggr_method: aggrMethod }),
-    ...(nodeIDs && nodeIDs.length && { node_ids: nodeIDs.join(",") }),
   }
 
   const onSuccessCallback = (data: {}) => {

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -92,7 +92,7 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
   const {
     // props for api
     host, chart, format, points, group, gtime, options,
-    after, before, dimensions, aggrMethod, nodeIDs,
+    after, before, dimensions,
     // props for the store
     fetchDataParams, id, cancelTokenSource,
   } = payload


### PR DESCRIPTION
Remove context and other composite-charts related params. When we'll release composite-charts, that will be replaced with separate POST call which is already in develop/staging

The 2.0.1-context-hotfix branch has been created from last commit in Dashboard which is currently in cloud's production