### PR TITLE
legend-and-spinner-improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "main": "./lib/src/index-npm.js",
   "homepage": ".",
   "files": [

--- a/src/domains/chart/components/chart-legend-bottom.styled.ts
+++ b/src/domains/chart/components/chart-legend-bottom.styled.ts
@@ -28,6 +28,8 @@ export const DateTimeSeparator = styled.span`
 export const LegendItems = styled.div`
   display: flex;
   flex-wrap: wrap;
+  overflow: auto;
+  max-height: 80px;
 `
 
 export const DimensionItem = styled.div<{ color: string, isDisabled: boolean }>`

--- a/src/domains/chart/components/chart-spinner/chart-spinner.tsx
+++ b/src/domains/chart/components/chart-spinner/chart-spinner.tsx
@@ -8,15 +8,16 @@ interface Props {
 export const ChartSpinner = ({
   chartLibrary,
 }: Props) => {
-  const top = chartLibrary === "dygraph" ? 30 : 0
+  const top = chartLibrary === "dygraph" ? 35 : 0
   const right = chartLibrary === "dygraph" ? 10 : 0
+  const size = chartLibrary === "dygraph" ? 36 : 18
   return (
-    <S.GifSpinnerContainer style={{ width: "10px", height: "10px" }} top={top} right={right}>
+    <S.GifSpinnerContainer size={size} top={top} right={right}>
       <svg
         shapeRendering="geometricPrecision"
         textRendering="geometricPrecision"
         viewBox="0 0 20 20"
-        transform="translate(0,-5)"
+        transform="translate(0,0)"
       >
         <g transform="translate(10,9) translate(-8,-9)">
           <S.SvgCircle

--- a/src/domains/chart/components/chart-spinner/styled.ts
+++ b/src/domains/chart/components/chart-spinner/styled.ts
@@ -12,11 +12,13 @@ const svgSpinnerAnimation = keyframes`
   }
 `
 
-export const GifSpinnerContainer = styled.div<{ top: number, right: number }>`
+export const GifSpinnerContainer = styled.div<{ top: number, right: number, size: number }>`
   position: absolute;
   top: ${prop("top")}px;
   right: ${prop("right")}px;
-  opacity: .5;
+  width: ${prop("size")}px;
+  height: ${prop("size")}px;
+  opacity: .4;
 `
 
 export const SvgSpinner = styled.g`

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -386,7 +386,9 @@ export const ChartWithLoader = ({
         setSelectedDimensions={setSelectedDimensions}
         showLatestOnBlur={!panAndZoom}
       />
-      {(shouldShowSpinner || showSpinnerAlways) && <ChartSpinner chartLibrary={attributes.chartLibrary} />}
+      {(shouldShowSpinner || showSpinnerAlways) && (
+        <ChartSpinner chartLibrary={attributes.chartLibrary} />
+      )}
       {dropdownMenu && (dropdownMenu.length > 0) && (
         <S.ChartDropdownContainer>
           <ChartDropdown

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -61,6 +61,8 @@ export type RenderCustomElementForDygraph = (selectedChartConfiguration: {
   getChartData: () => ChartData | null
 }) => JSX.Element
 
+const showSpinnerAlways = Boolean(localStorage.getItem("show-spinner-always"))
+
 export type Props = {
   attributes: Attributes
   chartUuid: string
@@ -384,7 +386,7 @@ export const ChartWithLoader = ({
         setSelectedDimensions={setSelectedDimensions}
         showLatestOnBlur={!panAndZoom}
       />
-      {shouldShowSpinner && <ChartSpinner chartLibrary={attributes.chartLibrary} />}
+      {(shouldShowSpinner || showSpinnerAlways) && <ChartSpinner chartLibrary={attributes.chartLibrary} />}
       {dropdownMenu && (dropdownMenu.length > 0) && (
         <S.ChartDropdownContainer>
           <ChartDropdown

--- a/src/domains/dashboard/components/node-view/node-view.scss
+++ b/src/domains/dashboard/components/node-view/node-view.scss
@@ -62,6 +62,10 @@ $CLOUD_SECONDARY_HEADER_HEIGHT: 64px;
       text-align: start ;
     }
 
+    .dygraph-chart--legend-bottom .dygraph-title {
+      text-indent: 0;
+    }
+
     .dashboard-section {
       h1 {
         margin-top: 20px;


### PR DESCRIPTION
- indent dygraph-title to the left, when legend is on the bottom
- bigger spinner for gauge/pie charts, even bigger for dygraphs
- expose spinner to show-spinner-always localstorage property (for debugging reasons)
- add max-height and auto-scrollbar, in case there are too many rows of legend-on-the-bottom