### PR TITLE
composite-charts-heads-fix

### DIFF
--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -128,7 +128,7 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
       filter: {
         nodeIDs,
         context: chart,
-        dimensions: dimensions && dimensions.split(/['|]/),
+        dimensions: dimensions ? dimensions.split(/['|]/) : undefined,
       },
       after,
       before,

--- a/src/domains/dashboard/components/node-view/node-view.tsx
+++ b/src/domains/dashboard/components/node-view/node-view.tsx
@@ -3,6 +3,7 @@ import React, {
 } from "react"
 import { useScroll } from "react-use"
 import { name2id } from "utils/name-2-id"
+import { mapDefaultAggrMethod } from "utils/fill-missing-data"
 import { ChartsMetadata } from "domains/global/types"
 import { Attributes, ChartsAttributes } from "domains/chart/utils/transformDataAttributes"
 import { DropdownMenu } from "domains/chart/components/chart-dropdown"
@@ -81,10 +82,10 @@ const SubSection = memo(({
                   {
                     ...attributes,
                     forceTimeWindow: true, // respect timeWindow
+                    aggrMethod: mapDefaultAggrMethod(chartsMetadata.charts[attributes.id].units),
                     host,
                     nodeIDs,
                     ...commonAttributesOverrides,
-                    ...(attributesOverrides && attributesOverrides[attributes.id]),
                   }
                 }
                 key={`${attributes.id}-${attributes.dimensions}`}

--- a/src/domains/dashboard/components/node-view/render-submenu-name.tsx
+++ b/src/domains/dashboard/components/node-view/render-submenu-name.tsx
@@ -88,7 +88,12 @@ export const renderSubmenuName = ({
           .map(parseChartString)
           .map((attributes: Attributes | null) => attributes && (
             <ChartWrapper
-              attributes={{ ...attributes, host, nodeIDs }}
+              attributes={{
+                ...attributes,
+                ...commonAttributesOverrides,
+                host,
+                nodeIDs,
+              }}
               key={`${attributes.id}-${attributes.dimensions}`}
               chartMetadata={chartsMetadata.charts[attributes.id]}
             />

--- a/src/domains/dashboard/components/node-view/render-submenu-name.tsx
+++ b/src/domains/dashboard/components/node-view/render-submenu-name.tsx
@@ -7,6 +7,7 @@ import { RenderCustomElementForDygraph } from "domains/chart/components/chart-wi
 import { LEGEND_BOTTOM_SINGLE_LINE_HEIGHT } from "domains/chart/utils/legend-utils"
 import { ChartsMetadata } from "domains/global/types"
 import { NODE_VIEW_DYGRAPH_TITLE_HEIGHT } from "utils"
+import { mapDefaultAggrMethod } from "utils/fill-missing-data"
 
 import { prioritySort } from "../../utils/sorting"
 import { parseChartString } from "../../utils/parse-chart-string"
@@ -91,6 +92,7 @@ export const renderSubmenuName = ({
               attributes={{
                 ...attributes,
                 ...commonAttributesOverrides,
+                aggrMethod: mapDefaultAggrMethod(chartsMetadata.charts[attributes.id].units),
                 host,
                 nodeIDs,
               }}


### PR DESCRIPTION
fix heads and mainheads to use default aggrMethod (separate from selected option for dygraphs in the cloud)
fix GET calls instead of composite-chart POST for heads