### PR TITLE
dashboard styling fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import React, {
 } from "react"
 import Ps from "perfect-scrollbar"
 import { ThemeProvider } from "styled-components"
-import { DefaultTheme } from "@netdata/netdata-ui"
 
 // intentionally loading before bootstrap styles
 import "./styles/main.css"
@@ -22,7 +21,12 @@ import { loadCss } from "utils/css-loader"
 import { useDateTime } from "utils/date-time"
 import { useListenToPostMessage } from "utils/post-message"
 import { useSelector } from "store/redux-separate-context"
-import { selectCloudBaseUrl, selectHasFetchedInfo, selectSignInUrl } from "domains/global/selectors"
+import {
+  selectCloudBaseUrl,
+  selectHasFetchedInfo,
+  selectSignInUrl,
+  selectTheme,
+} from "domains/global/selectors"
 import { Portals } from "domains/chart/components/portals"
 import { useChartsMetadata } from "domains/dashboard/hooks/use-charts-metadata"
 import { PrintModal } from "domains/dashboard/components/print-modal"
@@ -42,6 +46,7 @@ import "./types/global"
 
 import { useInfo } from "hooks/use-info"
 import { serverStatic } from "utils/server-detection"
+import { mapTheme } from "utils/map-theme"
 import {
   netdataCallback,
   updateLocaleFunctions,
@@ -141,9 +146,10 @@ const App: React.FC = () => {
   const signInUrl = useSelector(selectSignInUrl)
 
   const hasFetchedInfo = useSelector(selectHasFetchedInfo)
+  const theme = useSelector(selectTheme)
 
   return (
-    <ThemeProvider theme={DefaultTheme}>
+    <ThemeProvider theme={mapTheme(theme)}>
       {hasFetchDependencies && (
         // this needs to render after dynamic css files are loaded, otherwise netdata-ui
         // styling will have smaller priority than bootstrap css

--- a/src/components/app-header/styled.ts
+++ b/src/components/app-header/styled.ts
@@ -12,7 +12,7 @@ export const StyledHeader = styled.header`
   position: fixed;
   height: 56px;
   width: 100%;
-  background: ${getColor("tooltip")};
+  background: ${getColor(["gray", "limedSpruce"])};
   display: flex;
   flex-flow: row nowrap;
 

--- a/src/components/app-header/styled.ts
+++ b/src/components/app-header/styled.ts
@@ -76,7 +76,7 @@ export const IconContainer = styled.div`
 `
 export const IframeContainer = styled.div`
   position: relative;
-  width: 130px;
+  width: 134px;
   height: 40px;
 `
 
@@ -97,19 +97,20 @@ export const SignInButton = styled.a<{ isDisabled: boolean }>`
   height: 40px;
   font-weight: bold;
   font-size: 12px;
-  color: #FFF;
   flex-flow: row nowrap;
   align-items: center;
-  text-decoration: none;
   user-select: none;
   display: flex;
   text-transform: uppercase;
   justify-content: center;
+  &, &:hover {
+    color: #FFF;
+    text-decoration: none;
+  }
   &:hover {
-    border-color: #00CB51;
+    border-color: ${getColor("accent")};
     border-width: 3px;
     border-radius: 4px;
-    text-decoration: none;
   }
 `
 

--- a/src/components/app-header/styled.ts
+++ b/src/components/app-header/styled.ts
@@ -104,7 +104,7 @@ export const SignInButton = styled.a<{ isDisabled: boolean }>`
   text-transform: uppercase;
   justify-content: center;
   &, &:hover {
-    color: #FFF;
+    color: ${getColor("bright")};
     text-decoration: none;
   }
   &:hover {

--- a/src/components/space-panel/styled.ts
+++ b/src/components/space-panel/styled.ts
@@ -122,18 +122,25 @@ export const SignInButton = styled.a`
   border-style:solid;
   border-radius: 3px;
   border-width: 0;
-  width: 128px;
+  width: 134px;
   height: 40px;
   font-weight: bold;
   font-size: 12px;
-  color: #FFF;
   flex-flow: row nowrap;
   align-items: center;
-  text-decoration: none;
   user-select: none;
   display: flex;
   text-transform: uppercase;
   justify-content: center;
+  &, &:hover {
+    color: #FFF;
+    text-decoration: none;
+  }
+  &:hover {
+    border-color: ${getColor("accent")};
+    border-width: 3px;
+    border-radius: 4px;
+  }
 `
 
 export const NoNetworkIcon = styled.svg`

--- a/src/components/spaces-bar/styled.tsx
+++ b/src/components/spaces-bar/styled.tsx
@@ -10,7 +10,7 @@ export const ListContainer = styled.div`
   top: 56px;
   height: calc(100vh - 56px);
   width: ${getSizeBy(7)};
-  background: ${getColor("tooltip")};
+  background: ${getColor(["gray", "limedSpruce"])};
   padding-top: ${getSizeBy(2)};
   display: flex;
   flex-direction: column;

--- a/src/components/time-group/styled.ts
+++ b/src/components/time-group/styled.ts
@@ -8,6 +8,7 @@ export const ButtonGroup = styled.div`
   align-items: center;
   justify-content: flex-end;
   height: 100%;
+  color: ${getColor(["gray", "aluminium"])};
 `
 
 export const TimeButton = styled.button<{ isSelected: boolean }>`

--- a/src/domains/dashboard/components/sidebar-social-media/sidebar-social-media.tsx
+++ b/src/domains/dashboard/components/sidebar-social-media/sidebar-social-media.tsx
@@ -10,7 +10,7 @@ export const SidebarSocialMedia = () => (
             Do you like Netdata?
         </S.GithubCopyLine>
         <S.GithubStarQuestion href="https://github.com/netdata/netdata/" target="_blank">
-            Give us a star?
+            Give us a star!
         </S.GithubStarQuestion>
       </S.GithubCopy>
       <S.GithubIcon href="https://github.com/netdata/netdata/" target="_blank">

--- a/src/domains/dashboard/components/sidebar-social-media/styled.ts
+++ b/src/domains/dashboard/components/sidebar-social-media/styled.ts
@@ -4,7 +4,8 @@ import { getSizeBy, getColor } from "@netdata/netdata-ui"
 export const SocialMediaContainer = styled.div`
   width: 185px;
   padding: ${getSizeBy(2)};
-  background: ${getColor("mainBackground")};
+  background: ${getColor("borderSecondary")};
+
   font-size: 12px;
   margin-bottom: ${getSizeBy(3)};
 `
@@ -22,24 +23,29 @@ export const GithubCopyLine = styled.div`
 
 `
 
-export const GithubStarQuestion = styled.a`
+export const SocialMediaLink = styled.a`
+  &, &:hover {
+    color: ${getColor("main")};
+  }
 `
 
-export const GithubIcon = styled.a`
+export const GithubStarQuestion = styled(SocialMediaLink)``
+
+export const GithubIcon = styled(SocialMediaLink)`
   font-size: 24px;
 `
 
-export const TwitterIcon = styled.a`
+export const TwitterIcon = styled(SocialMediaLink)`
   font-size: 17px;
 `
 
-export const FacebookIcon = styled.a`
+export const FacebookIcon = styled(SocialMediaLink)`
   font-size: 23px;
 `
 
 export const Separator = styled.div`
   margin-top: ${getSizeBy(2)};
-  border-top: 1px solid ${getColor("disabled")};
+  border-top: 1px solid ${getColor("separator")};
 
 `
 export const SecondRow = styled.div`

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -723,3 +723,7 @@ body.modal-open {
         display: block;
     }
 }
+
+#ssoifrm {
+    display: none;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -5,7 +5,7 @@ html {
 
 /* prevent body from hiding under the navbar */
 body {
-    padding-top: 50px;
+    padding-top: 104px;
 }
 
 .navbar-highlight {

--- a/src/utils/map-theme.ts
+++ b/src/utils/map-theme.ts
@@ -1,0 +1,8 @@
+import { DefaultTheme, DarkTheme } from "@netdata/netdata-ui"
+
+export type DashboardTheme = "white" | "slate"
+
+export const mapTheme = (theme: DashboardTheme) => ({
+  slate: DarkTheme,
+  white: DefaultTheme,
+})[theme] || DarkTheme


### PR DESCRIPTION
- make header colors constant, because it's not yet ready for changing theme
- sign-in buttons hover fixes
- propagate Dashboard's theme from localStorage to styled-components
- social media links styling (fixed white theme, correct typo)
- hide small white dot, left from old iframe
- add more space on top so first header is visible below the new time-frame bar