### PR TITLE
submenu-info html fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/dashboard/components/node-view/render-submenu-name.tsx
+++ b/src/domains/dashboard/components/node-view/render-submenu-name.tsx
@@ -79,9 +79,11 @@ export const renderSubmenuName = ({
         <div
           className="dashboard-submenu-info"
           role="document"
-        >
-          {submenuInfo}
-        </div>
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: submenuInfo,
+          }}
+        />
       )}
       <div className="netdata-chart-row">
         {chartsSorted


### PR DESCRIPTION
related issue: https://github.com/netdata/netdata/issues/10118
Use dangerouslySetInnerHTML to display submenu info written in HTML in dashboard_info.js, just like we do it for other parts in node-view.