### PR TITLE
Group by node

### DIFF
--- a/src/domains/chart/actions.ts
+++ b/src/domains/chart/actions.ts
@@ -39,6 +39,7 @@ export interface FetchDataUrlParams {
   before?: number | null
   dimensions?: string
   aggrMethod?: string
+  dimensionsAggrMethod?: string
   nodeIDs?: string[]
   httpMethod?: Method
   groupBy?: "node" | "dimension"

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -63,6 +63,10 @@ export type RenderCustomElementForDygraph = (selectedChartConfiguration: {
 
 const showSpinnerAlways = Boolean(localStorage.getItem("show-spinner-always"))
 
+const dimensionsAggrMethodMap = {
+  "sum-of-abs": "sum",
+}
+
 export type Props = {
   attributes: Attributes
   chartUuid: string
@@ -295,7 +299,10 @@ export const ChartWithLoader = ({
           after: after || null,
           before: before || null,
           dimensions: attributes.dimensions,
-          aggrMethod: attributes.aggrMethod === "sum-of-abs" ? "sum" : attributes.aggrMethod,
+          aggrMethod: attributes.aggrMethod,
+          // @ts-ignore
+          dimensionsAggrMethod: dimensionsAggrMethodMap[attributes.dimensionsAggrMethod]
+            || attributes.dimensionsAggrMethod,
           nodeIDs,
           httpMethod: attributes.httpMethod,
           groupBy: attributes.groupBy,

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -295,7 +295,7 @@ export const ChartWithLoader = ({
           after: after || null,
           before: before || null,
           dimensions: attributes.dimensions,
-          aggrMethod: attributes.aggrMethod,
+          aggrMethod: attributes.aggrMethod === "sum-of-abs" ? "sum" : attributes.aggrMethod,
           nodeIDs,
           httpMethod: attributes.httpMethod,
           groupBy: attributes.groupBy,

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -58,7 +58,7 @@ export type RenderCustomElementForDygraph = (selectedChartConfiguration: {
   attributes: Attributes
   chartMetadata: ChartMetadata
   chartID: string
-  getChartData: () => ChartData | null
+  chartData: ChartData | null
 }) => JSX.Element
 
 const showSpinnerAlways = Boolean(localStorage.getItem("show-spinner-always"))
@@ -362,7 +362,7 @@ export const ChartWithLoader = ({
       attributes,
       chartMetadata: actualChartMetadata as ChartMetadata,
       chartID: id,
-      getChartData: () => chartData,
+      chartData,
     }), [renderCustomElementForDygraph, attributes, id, actualChartMetadata, chartData],
   )
 

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -897,6 +897,29 @@ export const DygraphChart = ({
     dygraphFillAlpha, hasEmptyData, isFakeStacked, isRemotelyControlled, orderedColors,
     requestedViewRange, viewAfter, viewBefore])
 
+  useUpdateEffect(() => {
+    if (!dygraphInstance.current) {
+      return
+    }
+
+    const dygraphOptionsStatic = getInitialDygraphOptions({
+      attributes,
+      chartData,
+      chartMetadata,
+      chartSettings,
+      dimensionsVisibility,
+      hiddenLabelsElementId,
+      isFakeStacked,
+      orderedColors,
+      setMinMax,
+      shouldSmoothPlot,
+      unitsCurrent,
+      xAxisDateString,
+      xAxisTimeString,
+    })
+    dygraphInstance.current.updateOptions(dygraphOptionsStatic)
+  }, [dygraphChartType])
+
 
   // set selection
   const currentSelectionMasterId = useSelector(selectGlobalSelectionMaster)

--- a/src/domains/chart/components/lib-charts/dygraph/utils.ts
+++ b/src/domains/chart/components/lib-charts/dygraph/utils.ts
@@ -37,6 +37,10 @@ export const getDataForFakeStacked = (
   ]
 })
 
+const isPercentage = (unit: string) => unit === "percentage"
+  || unit === "percent"
+  || unit.indexOf("%") !== -1
+
 export const getDygraphChartType = (
   attributes: Attributes, chartData: DygraphData, chartMetadata: ChartMetadata,
   chartSettings: ChartLibraryConfig,
@@ -44,7 +48,13 @@ export const getDygraphChartType = (
   const isLogScale = (chartSettings.isLogScale as ((a: Attributes) => boolean))(attributes)
   const {
     dygraphType: dygraphRequestedType = chartMetadata.chart_type,
+    groupBy,
   } = attributes
+
+  if (groupBy === "node" && isPercentage(chartMetadata.units)) {
+    return "line"
+  }
+
   // corresponds to state.tmp.dygraph_chart_type in old app
   let dygraphChartType = dygraphRequestedType
   if (dygraphChartType === "stacked" && chartData.dimensions === 1) {

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -93,7 +93,7 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
     // props for api
     host, chart, format, points, group, gtime, options,
     after, before, dimensions, aggrMethod, nodeIDs, httpMethod,
-    // groupBy = "dimension", // group by node or dimension
+    groupBy = "dimension", // group by node or dimension
     // props for the store
     fetchDataParams, id, cancelTokenSource,
   } = payload
@@ -140,14 +140,14 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
       aggregation: {
         method: aggrMethod,
       },
-      // aggregations: [groupBy === "node" && {
-      //   method: "sum",
-      //   groupBy: ["chart", "node"],
-      // },
-      // {
-      //   method: aggrMethod,
-      //   groupBy: [groupBy],
-      // }].filter(Boolean),
+      aggregations: [groupBy === "node" && {
+        method: "sum",
+        groupBy: ["chart", "node"],
+      },
+      {
+        method: aggrMethod,
+        groupBy: [groupBy],
+      }].filter(Boolean),
     },
   } : {
     params: {
@@ -200,7 +200,7 @@ function fetchDataForSnapshotSaga({ payload }: Action<FetchDataForSnapshotPayloa
   const {
     host, chart, format, points, group, gtime, options,
     after, before, dimensions, aggrMethod,
-    // groupBy,
+    groupBy,
     nodeIDs,
     chartLibrary, id,
   } = payload
@@ -226,7 +226,7 @@ function fetchDataForSnapshotSaga({ payload }: Action<FetchDataForSnapshotPayloa
     dimensions,
     ...(aggrMethod && { aggr_method: aggrMethod }),
     ...(nodeIDs && { node_ids: nodeIDs.join(",") }),
-    // ...(groupBy && { groupBy }),
+    ...(groupBy && { groupBy }),
   }
 
   const onSuccessCallback = (data: unknown) => {

--- a/src/domains/chart/sagas.ts
+++ b/src/domains/chart/sagas.ts
@@ -92,7 +92,7 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
   const {
     // props for api
     host, chart, format, points, group, gtime, options,
-    after, before, dimensions, aggrMethod, nodeIDs, httpMethod,
+    after, before, dimensions, aggrMethod, dimensionsAggrMethod = "sum", nodeIDs, httpMethod,
     groupBy = "dimension", // group by node or dimension
     // props for the store
     fetchDataParams, id, cancelTokenSource,
@@ -137,11 +137,8 @@ function* fetchDataSaga({ payload }: Action<FetchDataPayload>) {
       group,
       gtime,
       agent_options: options.split("|"),
-      aggregation: {
-        method: aggrMethod,
-      },
       aggregations: [groupBy === "node" && {
-        method: "sum",
+        method: dimensionsAggrMethod,
         groupBy: ["chart", "node"],
       },
       {

--- a/src/domains/chart/utils/get-chart-url-options.ts
+++ b/src/domains/chart/utils/get-chart-url-options.ts
@@ -24,5 +24,9 @@ export const getChartURLOptions = (
     ret += "|nonzero"
   }
 
+  if (attributes.aggrMethod === "sum-of-abs") {
+    ret += "|absolute"
+  }
+
   return ret
 }

--- a/src/domains/chart/utils/get-chart-url-options.ts
+++ b/src/domains/chart/utils/get-chart-url-options.ts
@@ -24,7 +24,8 @@ export const getChartURLOptions = (
     ret += "|nonzero"
   }
 
-  if (attributes.aggrMethod === "sum-of-abs") {
+  if (attributes.dimensionsAggrMethod === "sum-of-abs"
+    || (!attributes.dimensionsAggrMethod && attributes.groupBy === "node")) {
     ret += "|absolute"
   }
 

--- a/src/domains/chart/utils/transformDataAttributes.ts
+++ b/src/domains/chart/utils/transformDataAttributes.ts
@@ -89,6 +89,7 @@ export interface StaticAttributes {
   unitsCommon?: string
   unitsDesired?: string
   aggrMethod?: string
+  dimensionsAggrMethod?: string
   groupBy?: "node" | "dimension"
   nodeIDs?: string[]
   colors?: string
@@ -327,6 +328,7 @@ const getAttributesMap = (): AttributesMap => ({
   unitsCommon: { key: "common-units" },
   unitsDesired: { key: "desired-units" },
   aggrMethod: { key: "aggr-method" },
+  dimensionsAggrMethod: { key: "dimensions-aggr-method" },
   groupBy: { key: "group-by" },
   nodeIDs: { key: "node-ids" },
   colors: { key: "colors" },


### PR DESCRIPTION
- Adds the double aggregation logic that is required if the group is by node.
- Change chart type if it is required by the business logic