### PR TITLE
Resized the chart when dimensions change.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -929,7 +929,6 @@ export const DygraphChart = ({
     dygraphInstance.current.updateOptions(dygraphOptionsStatic)
   }, [dygraphChartType])
 
-
   // set selection
   const currentSelectionMasterId = useSelector(selectGlobalSelectionMaster)
   useLayoutEffect(() => {
@@ -955,7 +954,7 @@ export const DygraphChart = ({
     if (dygraphInstance.current) {
       (dygraphInstance.current as NetdataDygraph).resize()
     }
-  }, [resizeHeight])
+  }, [resizeHeight, chartData.dimension_names.length])
 
 
   const commonMinState = useSelector((state: AppStateT) => (


### PR DESCRIPTION
Resize the chart when the names in the legend are getting changed. So we avoid the issue in the following schreenshot.

<img width="551" alt="Screenshot 2020-11-11 at 6 23 06 PM" src="https://user-images.githubusercontent.com/2164902/98927970-dbdf0600-24e1-11eb-8db6-9be2696494e3.png">
