### PR TITLE
persist closed sidebar

### DIFF
--- a/src/components/app-header/components/panel-control/panel-control.tsx
+++ b/src/components/app-header/components/panel-control/panel-control.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 import { useSelector, useDispatch } from "react-redux"
+
+import { SPACE_PANEL_STATE } from "utils"
 import NetdataLogo from "./assets/netdata-logo.svg"
 import { LogoSection, LogoContainer, StyledButton } from "./styled"
 import { setSpacePanelStatusAction } from "../../../../domains/global/actions"
@@ -21,6 +23,7 @@ export const PanelControl = () => {
         flavour="borderless"
         icon="hamburger"
         onClick={() => {
+          localStorage.setItem(SPACE_PANEL_STATE, String(!spacePanelIsActive))
           dispatch(setSpacePanelStatusAction({ isActive: !spacePanelIsActive }))
         }}
         themeType="dark"

--- a/src/components/space-panel/space-panel.tsx
+++ b/src/components/space-panel/space-panel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react"
 import { useSelector, useDispatch } from "react-redux"
 
+import { SPACE_PANEL_STATE } from "utils"
 import {
   selectIsCloudEnabled,
   selectIsUsingGlobalRegistry,
@@ -63,7 +64,17 @@ export const SpacePanel = ({
   const panelIsActive = useSelector(selectSpacePanelIsActive)
 
   useEffect(() => {
-    dispatch(setSpacePanelStatusAction({ isActive: isSignedIn }))
+    const spacePanelStatePersisted = localStorage.getItem(SPACE_PANEL_STATE)
+    // control space panel from localStorage only when it's in closed state
+    // if we want to persist "opened" state, we need to fix a problem when we see invitation
+    // to cloud before sign-in state is propagated from iframes
+    // it can be difficult to detect and differentiate from the case where user uses space-panel
+    // to use registry and streamed-nodes
+    if (spacePanelStatePersisted === "false") {
+      dispatch(setSpacePanelStatusAction({ isActive: false }))
+    } else {
+      dispatch(setSpacePanelStatusAction({ isActive: isSignedIn }))
+    }
   }, [dispatch, isSignedIn])
 
   const streamedHostsData = getStreamedNodes(chartsMetadata)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -23,3 +23,5 @@ export const getInitialAfterFromWindow = () => {
   // var duration = Math.round(($(div).width() * pcent_width / 100 * data.update_every / 3) / 60) * 60;
   return -Math.round((div.getBoundingClientRect().width / 3) / 60) * 60
 }
+
+export const SPACE_PANEL_STATE = "space-panel-state"


### PR DESCRIPTION
When user manually closes the sidebar, persist it (in localStorage).

Side note - I didn't implemented persisting opened state for now, because that needs fixing the "pending" state where we see invitation-to-cloud in space-panel before sso iframes call back