### PR TITLE
custom-dashboards-app workflow fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "start": "REACT_APP_SHOULD_USE_DEFAULT_CONTEXT=true craco start",
     "start:console": "cp ../console.html public/index.html && npm run start",
     "start:node-view": "APP_NAME='node-view-app.tsx' HTML_FILE_NAME='index-node-view.html' npm run start",
-    "start:tv": "cd public && rm ./index.html && ln -s ../tv.html index.html && cd .. && npm run start",
+    "start:tv": "cd public && rm ./index.html && ln -s ../tv.html index.html && cd .. && APP_NAME='custom-dashboards-app.tsx' REACT_APP_IS_MAIN_DASHBOARD=true npm run start",
     "start:dashboard": "REACT_APP_IS_MAIN_DASHBOARD=true npm run start",
     "build": "REACT_APP_IS_MAIN_DASHBOARD=true REACT_APP_SHOULD_USE_DEFAULT_CONTEXT=true craco build",
     "test": "REACT_APP_SHOULD_USE_DEFAULT_CONTEXT=true react-scripts test --env=jest-environment-jsdom-fourteen --watchAll=false",

--- a/src/custom-dashboards-app.tsx
+++ b/src/custom-dashboards-app.tsx
@@ -1,11 +1,15 @@
 import React from "react"
 import Ps from "perfect-scrollbar"
+import { ThemeProvider } from "styled-components"
 
 import { loadCss } from "utils/css-loader"
+import { mapTheme } from "utils/map-theme"
 import "domains/chart/utils/jquery-loader"
 import { Portals } from "domains/chart/components/portals"
 import { useRegistry } from "hooks/use-registry"
 import { useAlarms } from "hooks/use-alarms"
+import { useSelector } from "store/redux-separate-context"
+import { selectTheme } from "domains/global/selectors"
 
 import "./types/global"
 
@@ -34,10 +38,14 @@ const CustomDashboardsApp: React.FC = () => { // eslint-disable-line arrow-body-
   const shouldUseAlarms = !!window.netdataShowAlarms
   useAlarms(shouldUseAlarms)
 
+  const theme = useSelector(selectTheme)
+
   return (
-    <div className="App">
-      <Portals />
-    </div>
+    <ThemeProvider theme={mapTheme(theme)}>
+      <div className="App">
+        <Portals />
+      </div>
+    </ThemeProvider>
   )
 }
 


### PR DESCRIPTION
- fix start:tv task
- add themeProvider to custom-dashboards-app, since it's needed by charts