### PR TITLE
reset relative zoom

### DIFF
--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -8,6 +8,7 @@ import {
   requestCommonColorsAction,
   resetGlobalPanAndZoomAction,
   setDefaultAfterAction,
+  resetDefaultAfterAction,
   setGlobalPanAndZoomAction,
   setGlobalSelectionAction,
 } from "domains/global/actions"
@@ -344,11 +345,15 @@ export const Chart = memo(({
 
   const handleToolboxResetClick = useCallback(() => {
     if (isSyncPanAndZoom) {
-      dispatch(resetGlobalPanAndZoomAction())
+      if (globalPanAndZoom) {
+        dispatch(resetGlobalPanAndZoomAction())
+      } else {
+        dispatch(resetDefaultAfterAction())
+      }
     } else {
       dispatch(resetChartPanAndZoomAction({ id: chartUuid }))
     }
-  }, [chartUuid, dispatch, isSyncPanAndZoom])
+  }, [chartUuid, dispatch, globalPanAndZoom, isSyncPanAndZoom])
 
   /**
    * assign colors

--- a/src/domains/chart/components/disable-out-of-view.tsx
+++ b/src/domains/chart/components/disable-out-of-view.tsx
@@ -38,6 +38,8 @@ const cloneWithCanvas = (element: HTMLElement) => {
   return cloned
 }
 
+const shouldCleanChartStateAlways = localStorage.getItem("wipe-chart-state")
+
 interface Props {
   attributes: Attributes
   chartUuid: string
@@ -109,6 +111,12 @@ export const DisableOutOfView = ({
   ) {
     previousIsVisibleIntersection.current = isVisibleIntersection
   }
+
+  useEffect(() => {
+    if (!isPrintMode && shouldHide && shouldCleanChartStateAlways) {
+      dispatch(clearChartStateAction({ id: chartUuid }))
+    }
+  }, [chartUuid, dispatch, shouldHide])
 
 
   if (isPrintMode) {

--- a/src/domains/global/actions.ts
+++ b/src/domains/global/actions.ts
@@ -49,6 +49,8 @@ export const setDefaultAfterAction = createAction<SetDefaultAfterAction>(
   `${storeKey}/setDefaultAfterAction`,
 )
 
+export const resetDefaultAfterAction = createAction(`${storeKey}/resetDefaultAfterAction`)
+
 export interface SetGlobalChartUnderlayAction {
   after: number
   before: number

--- a/src/domains/global/reducer.ts
+++ b/src/domains/global/reducer.ts
@@ -30,6 +30,7 @@ import {
   setSpacePanelTransitionEndAction,
   resetRegistry,
   accessRegistrySuccessAction,
+  resetDefaultAfterAction,
 } from "./actions"
 import {
   Options, optionsMergedWithLocalStorage, getOptionsMergedWithLocalStorage, clearLocalStorage,
@@ -332,6 +333,11 @@ globalReducer.on(resetGlobalPanAndZoomAction, (state) => ({
 globalReducer.on(setDefaultAfterAction, (state, { after }) => ({
   ...state,
   defaultAfter: after,
+}))
+
+globalReducer.on(resetDefaultAfterAction, (state) => ({
+  ...state,
+  defaultAfter: initialState.defaultAfter,
 }))
 
 globalReducer.on(setGlobalChartUnderlayAction, (state, { after, before, masterID }) => ({


### PR DESCRIPTION
- allow resetting relative zoom when current setting is already relative - when "play" button is pressed and the mode is "relative" (last x minutes etc.), then the timeframe is reset to the initial value
- allow testing "aggresive chart state cleaning" impact on performance - if `wipe-chart-state` property in localStorage is truthy, then when chart scroll out of view it destroys the state