### PR TITLE
dygraph panning responsiveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.11.5",
+  "version": "2.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18239,6 +18239,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-debounce": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-5.2.0.tgz",
+      "integrity": "sha512-lW4tbPsTnvPKYqOYXp5xZ7SP7No/ARLqqQqoyRKuSzP0HxR9arhSAhznXUZFoNPWDRij8fog+N6sYbjb8c3kzw=="
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "tableexport.jquery.plugin": "^1.6.7",
     "typeface-ibm-plex-sans": "0.0.75",
     "typescript": "^3.7.3",
+    "use-debounce": "^5.2.0",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.11.5",
+  "version": "2.12.0",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/chart/chart-types.ts
+++ b/src/domains/chart/chart-types.ts
@@ -109,6 +109,7 @@ export interface ChartState {
     masterID?: string
     shouldForceTimeRange?: boolean
   }
+  viewRange: null | [number, number]
 
   fetchDataParams: {
     isRemotelyControlled: boolean

--- a/src/domains/chart/components/abstract-chart.tsx
+++ b/src/domains/chart/components/abstract-chart.tsx
@@ -49,9 +49,8 @@ interface Props {
   setMinMax: (minMax: [number, number]) => void
   showLatestOnBlur: boolean
   unitsCurrent: string
-  viewAfter: number,
-  viewBefore: number,
-  requestedViewRange: TimeRange
+  viewAfterForCurrentData: number,
+  viewBeforeForCurrentData: number,
 }
 
 export const AbstractChart = ({
@@ -77,9 +76,8 @@ export const AbstractChart = ({
   setMinMax,
   showLatestOnBlur,
   unitsCurrent,
-  viewAfter,
-  viewBefore,
-  requestedViewRange,
+  viewAfterForCurrentData,
+  viewBeforeForCurrentData,
 }: Props) => {
   const dispatch = useDispatch()
 
@@ -90,11 +88,18 @@ export const AbstractChart = ({
     // freeze charts
     // don't send masterID, so no padding is applied
     if (isSyncPanAndZoom) {
-      dispatch(setGlobalPanAndZoomAction({ after: viewAfter, before: viewBefore }))
+      dispatch(setGlobalPanAndZoomAction({
+        after: viewAfterForCurrentData,
+        before: viewBeforeForCurrentData,
+      }))
     } else {
-      dispatch(setChartPanAndZoomAction({ after: viewAfter, before: viewBefore, id: chartUuid }))
+      dispatch(setChartPanAndZoomAction({
+        after: viewAfterForCurrentData,
+        before: viewBeforeForCurrentData,
+        id: chartUuid,
+      }))
     }
-  }, [chartUuid, dispatch, isSyncPanAndZoom, viewAfter, viewBefore])
+  }, [chartUuid, dispatch, isSyncPanAndZoom, viewAfterForCurrentData, viewBeforeForCurrentData])
 
   const chartSettings = chartLibrariesSettings[chartLibrary]
   const { hasLegend } = chartSettings
@@ -139,8 +144,8 @@ export const AbstractChart = ({
         setMinMax={setMinMax}
         showUndefined={showUndefined}
         unitsCurrent={unitsCurrent}
-        viewAfter={viewAfter}
-        viewBefore={viewBefore}
+        viewAfter={viewAfterForCurrentData}
+        viewBefore={viewBeforeForCurrentData}
       />
     )
   }
@@ -170,8 +175,8 @@ export const AbstractChart = ({
         setMinMax={setMinMax}
         showUndefined={showUndefined}
         unitsCurrent={unitsCurrent}
-        viewAfter={viewAfter}
-        viewBefore={viewBefore}
+        viewAfter={viewAfterForCurrentData}
+        viewBefore={viewBeforeForCurrentData}
       />
     )
   }
@@ -189,7 +194,8 @@ export const AbstractChart = ({
         isRemotelyControlled={isRemotelyControlled}
         orderedColors={orderedColors}
         unitsCurrent={unitsCurrent}
-        requestedViewRange={requestedViewRange}
+        viewAfterForCurrentData={viewAfterForCurrentData}
+        viewBeforeForCurrentData={viewBeforeForCurrentData}
       />
     )
   }
@@ -278,9 +284,8 @@ export const AbstractChart = ({
       setHoveredX={setHoveredX}
       setMinMax={setMinMax}
       unitsCurrent={unitsCurrent}
-      viewAfter={viewAfter}
-      viewBefore={viewBefore}
-      requestedViewRange={requestedViewRange}
+      viewAfter={viewAfterForCurrentData}
+      viewBefore={viewBeforeForCurrentData}
     />
   )
 }

--- a/src/domains/chart/components/abstract-chart.tsx
+++ b/src/domains/chart/components/abstract-chart.tsx
@@ -42,6 +42,7 @@ interface Props {
   orderedColors: string[]
   hoveredX: number | null
   onUpdateChartPanAndZoom: (arg: { after: number, before: number, masterID: string }) => void
+  immediatelyDispatchPanAndZoom: () => void
 
   hoveredRow: number
   setHoveredX: (hoveredX: number | null, noMaster?: boolean) => void
@@ -71,6 +72,7 @@ export const AbstractChart = ({
   hoveredRow,
   hoveredX,
   onUpdateChartPanAndZoom,
+  immediatelyDispatchPanAndZoom,
   setHoveredX,
   setMinMax,
   showLatestOnBlur,
@@ -268,6 +270,7 @@ export const AbstractChart = ({
       hasLegend={hasLegend(attributes)}
       isRemotelyControlled={isRemotelyControlled}
       orderedColors={orderedColors}
+      immediatelyDispatchPanAndZoom={immediatelyDispatchPanAndZoom}
       hoveredRow={hoveredRow}
       hoveredX={hoveredX}
       onUpdateChartPanAndZoom={onUpdateChartPanAndZoom}

--- a/src/domains/chart/components/abstract-chart.tsx
+++ b/src/domains/chart/components/abstract-chart.tsx
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from "store/redux-separate-context"
 import { setGlobalChartUnderlayAction, setGlobalPanAndZoomAction } from "domains/global/actions"
 import { selectSyncPanAndZoom } from "domains/global/selectors"
 import { setChartPanAndZoomAction } from "domains/chart/actions"
-import { TimeRange } from "types/common"
 import { useShowValueOutside } from "hooks/use-show-value-outside"
 
 import { Attributes } from "../utils/transformDataAttributes"

--- a/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
+++ b/src/domains/chart/components/chart-with-loader/chart-with-loader.tsx
@@ -37,6 +37,7 @@ import {
   makeSelectChartMetadataRequest,
   selectChartPanAndZoom,
   selectChartIsFetchingData,
+  selectChartViewRange,
 } from "../../selectors"
 import {
   ChartData,
@@ -138,6 +139,9 @@ export const ChartWithLoader = ({
 
 
   const fetchDataParams = useSelector((state: AppStateT) => selectChartFetchDataParams(
+    state, { id: chartUuid },
+  ))
+  const viewRange = useSelector((state: AppStateT) => selectChartViewRange(
     state, { id: chartUuid },
   ))
   const chartData = useSelector((state: AppStateT) => selectChartData(state, { id: chartUuid }))
@@ -245,7 +249,7 @@ export const ChartWithLoader = ({
 
       let after
       let before
-      let viewRange
+      let newViewRange
       let pointsMultiplier = 1
 
       if (panAndZoom) {
@@ -253,7 +257,7 @@ export const ChartWithLoader = ({
           after = Math.round(panAndZoom.after / 1000)
           before = Math.round(panAndZoom.before / 1000)
 
-          viewRange = [after, before]
+          newViewRange = [after, before]
 
           if (shouldUsePanAndZoomPadding) {
             const requestedPadding = Math.round((before - after) / 2)
@@ -273,7 +277,7 @@ export const ChartWithLoader = ({
         pointsMultiplier = 1
       }
 
-      viewRange = (viewRange || [after, before]).map((x) => x * 1000) as [number, number]
+      newViewRange = (newViewRange || [after, before]).map((x) => x * 1000) as [number, number]
 
       const dataPoints = attributes.points
         || Math.round(chartWidth / getChartPixelsPerPoint({ attributes, chartSettings }))
@@ -316,7 +320,7 @@ export const ChartWithLoader = ({
             // those params should be synced with data
             fillMissingPoints: correctedPoints ? (points - correctedPoints) : undefined,
             isRemotelyControlled,
-            viewRange,
+            viewRange: newViewRange,
           },
           id: chartUuid,
           cancelTokenSource,
@@ -421,7 +425,10 @@ export const ChartWithLoader = ({
         globalPanAndZoom={globalPanAndZoom}
         hasEmptyData={hasEmptyData}
         isRemotelyControlled={fetchDataParams.isRemotelyControlled}
-        requestedViewRange={fetchDataParams.viewRange}
+        // view range that updates only when data is fetched
+        viewRangeForCurrentData={fetchDataParams.viewRange}
+        // view range that updates when requesting and fetching of data
+        viewRange={viewRange!}
         selectedDimensions={selectedDimensions}
         setSelectedDimensions={setSelectedDimensions}
         showLatestOnBlur={!panAndZoom}

--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -109,6 +109,7 @@ export const Chart = memo(({
     && !attributes.hideResizeHandler
 
   const dispatch = useDispatch()
+  const dimensionNamesJoined = chartData.dimension_names.join()
   const allDimensionNames = useMemo(
     () => {
       // metadata and chartData dimensions match each other, but we need to first parse
@@ -121,7 +122,9 @@ export const Chart = memo(({
       )
       return dimensionNamesFromMetadata.concat(additionalDimensionNamesFromData)
     },
-    [chartData.dimension_names, chartMetadata.dimensions],
+    // intentionally skipping chartData.dimension_names for better memoization
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dimensionNamesJoined, chartMetadata.dimensions],
   )
   useEffect(() => {
     dispatch(requestCommonColorsAction({

--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -114,7 +114,6 @@ export const Chart = memo(({
     && !attributes.hideResizeHandler
 
   const dispatch = useDispatch()
-  const dimensionNamesJoined = chartData.dimension_names.join()
   const allDimensionNames = useMemo(
     () => {
       // metadata and chartData dimensions match each other, but we need to first parse
@@ -127,9 +126,7 @@ export const Chart = memo(({
       )
       return dimensionNamesFromMetadata.concat(additionalDimensionNamesFromData)
     },
-    // intentionally skipping chartData.dimension_names for better memoization
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [dimensionNamesJoined, chartMetadata.dimensions],
+    [chartData.dimension_names, chartMetadata.dimensions],
   )
   useEffect(() => {
     dispatch(requestCommonColorsAction({

--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -290,6 +290,9 @@ export const Chart = memo(({
         masterID: chartUuid,
         shouldForceTimeRange,
       })
+      if (shouldFlushImmediately) {
+        setGlobalPanAndZoomDebounced.flush()
+      }
     } else {
       dispatch(setChartPanAndZoomAction({
         after: afterForced,
@@ -315,6 +318,7 @@ export const Chart = memo(({
       after: newAfter,
       before: newBefore,
       shouldForceTimeRange: true,
+      shouldFlushImmediately: true,
     })
   }, [handleUpdateChartPanAndZoom, netdataFirst, netdataLast])
 

--- a/src/domains/chart/components/lib-charts/__tests__/dygraph-chart.test.tsx
+++ b/src/domains/chart/components/lib-charts/__tests__/dygraph-chart.test.tsx
@@ -53,6 +53,7 @@ const dygraphDefaultProps = {
   hasEmptyData: false,
   hasLegend: true,
   hoveredRow: -1,
+  immediatelyDispatchPanAndZoom: () => {},
   legendFormatValue: (v: number) => v,
   onUpdateChartPanAndZoom: () => {},
   orderedColors: ["#ff00ff", "#00ffff", "#ffff00"],

--- a/src/domains/chart/components/lib-charts/__tests__/dygraph-chart.test.tsx
+++ b/src/domains/chart/components/lib-charts/__tests__/dygraph-chart.test.tsx
@@ -58,7 +58,7 @@ const dygraphDefaultProps = {
   onUpdateChartPanAndZoom: () => {},
   orderedColors: ["#ff00ff", "#00ffff", "#ffff00"],
   hoveredX: null,
-  requestedViewRange: [chartDataMock.after, chartDataMock.before] as TimeRange,
+  viewRange: [chartDataMock.after, chartDataMock.before] as TimeRange,
   setGlobalChartUnderlay: () => {},
   setHoveredX: () => {},
   setMinMax: () => {},

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -819,6 +819,7 @@ export const DygraphChart = ({
 
             // remember the timestamp of the last touch end
             dygraphLastTouchEnd.current = now
+            propsRef.current.immediatelyDispatchPanAndZoom()
           },
         },
       }

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -302,7 +302,6 @@ interface Props {
   unitsCurrent: string
   viewAfter: number
   viewBefore: number
-  requestedViewRange: TimeRange
 }
 export const DygraphChart = ({
   attributes,
@@ -329,7 +328,6 @@ export const DygraphChart = ({
   unitsCurrent,
   viewAfter,
   viewBefore,
-  requestedViewRange,
 }: Props) => {
   const globalChartUnderlay = useSelector(selectGlobalChartUnderlay)
 
@@ -887,7 +885,7 @@ export const DygraphChart = ({
       const hasChangedDuration = Math.abs((viewBefore - viewAfter) - (xAxisRange[1] - xAxisRange[0])) > timeframeThreshold
 
       // check if the time is relative
-      const hasScrolledToTheFutureDuringPlayMode = requestedViewRange[1] <= 0
+      const hasScrolledToTheFutureDuringPlayMode = viewBefore <= 0
       && (xAxisRange[1] > viewBefore)
       // if viewAfter is bigger than current dateWindow start, just reset dateWindow
       && (xAxisRange[0] > viewAfter)
@@ -915,7 +913,7 @@ export const DygraphChart = ({
     }
   }, [attributes, chartData.result, chartUuid, dimensionsVisibility, dygraphChartType,
     dygraphFillAlpha, hasEmptyData, isFakeStacked, isRemotelyControlled, orderedColors,
-    requestedViewRange, viewAfter, viewBefore])
+    viewAfter, viewBefore])
 
   useUpdateEffect(() => {
     if (!dygraphInstance.current) {

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -292,6 +292,7 @@ interface Props {
     shouldNotExceedAvailableRange: boolean,
   }) => void
   orderedColors: string[]
+  immediatelyDispatchPanAndZoom: () => void
 
   hoveredRow: number
   hoveredX: number | null
@@ -318,6 +319,7 @@ export const DygraphChart = ({
   isRemotelyControlled,
   onUpdateChartPanAndZoom,
   orderedColors,
+  immediatelyDispatchPanAndZoom,
 
   hoveredRow,
   hoveredX,
@@ -409,6 +411,7 @@ export const DygraphChart = ({
     chartData,
     globalChartUnderlay,
     hoveredX,
+    immediatelyDispatchPanAndZoom,
     // put it to ref to prevent additional updateOptions() after creating dygraph
     resetGlobalPanAndZoom,
     setGlobalChartUnderlay,
@@ -419,13 +422,14 @@ export const DygraphChart = ({
   useLayoutEffect(() => {
     propsRef.current.chartData = chartData
     propsRef.current.hoveredX = hoveredX
+    propsRef.current.immediatelyDispatchPanAndZoom = immediatelyDispatchPanAndZoom
     propsRef.current.globalChartUnderlay = globalChartUnderlay
     propsRef.current.resetGlobalPanAndZoom = resetGlobalPanAndZoom
     propsRef.current.setGlobalChartUnderlay = setGlobalChartUnderlay
     propsRef.current.updateChartPanOrZoom = updateChartPanOrZoom
     propsRef.current.viewAfter = viewAfter
     propsRef.current.viewBefore = viewBefore
-  }, [chartData, globalChartUnderlay, hoveredX, resetGlobalPanAndZoom,
+  }, [chartData, globalChartUnderlay, hoveredX, immediatelyDispatchPanAndZoom,
     setGlobalChartUnderlay, updateChartPanOrZoom, viewAfter, viewBefore])
 
   const shouldSmoothPlot = useSelector(selectSmoothPlot)
@@ -633,10 +637,12 @@ export const DygraphChart = ({
               latestIsUserAction.current = true
               // @ts-ignore
               Dygraph.endPan(event, dygraph, context)
+              propsRef.current.immediatelyDispatchPanAndZoom()
             } else if (context.isZooming) {
               latestIsUserAction.current = true
               // @ts-ignore
               Dygraph.endZoom(event, dygraph, context)
+              propsRef.current.immediatelyDispatchPanAndZoom()
             }
           },
 
@@ -826,7 +832,7 @@ export const DygraphChart = ({
   }, [attributes, chartData, chartMetadata, chartSettings, chartUuid, dimensionsVisibility,
     globalChartUnderlay, hasEmptyData, hiddenLabelsElementId, isFakeStacked, isMouseDown,
     orderedColors, setGlobalChartUnderlay, setHoveredX, setMinMax, shouldSmoothPlot, unitsCurrent,
-    updateChartPanOrZoom, xAxisDateString, xAxisTimeString, updatePrecededPosition])
+    xAxisDateString, xAxisTimeString, updatePrecededPosition, immediatelyDispatchPanAndZoom])
 
   useUpdateEffect(() => {
     if (dygraphInstance.current) {

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -428,7 +428,7 @@ export const DygraphChart = ({
     propsRef.current.viewAfter = viewAfter
     propsRef.current.viewBefore = viewBefore
   }, [chartData, globalChartUnderlay, hoveredX, immediatelyDispatchPanAndZoom,
-    setGlobalChartUnderlay, updateChartPanOrZoom, viewAfter, viewBefore])
+    resetGlobalPanAndZoom, setGlobalChartUnderlay, updateChartPanOrZoom, viewAfter, viewBefore])
 
   const shouldSmoothPlot = useSelector(selectSmoothPlot)
   useLayoutEffect(() => {
@@ -829,9 +829,9 @@ export const DygraphChart = ({
       dygraphInstance.current = instance
     }
   }, [attributes, chartData, chartMetadata, chartSettings, chartUuid, dimensionsVisibility,
-    globalChartUnderlay, hasEmptyData, hiddenLabelsElementId, isFakeStacked, isMouseDown,
-    orderedColors, setGlobalChartUnderlay, setHoveredX, setMinMax, shouldSmoothPlot, unitsCurrent,
-    xAxisDateString, xAxisTimeString, updatePrecededPosition, immediatelyDispatchPanAndZoom])
+    hasEmptyData, hiddenLabelsElementId, isFakeStacked,
+    orderedColors, setHoveredX, setMinMax, shouldSmoothPlot, unitsCurrent,
+    xAxisDateString, xAxisTimeString, updatePrecededPosition])
 
   useUpdateEffect(() => {
     if (dygraphInstance.current) {

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -412,6 +412,7 @@ export const DygraphChart = ({
     // put it to ref to prevent additional updateOptions() after creating dygraph
     resetGlobalPanAndZoom,
     setGlobalChartUnderlay,
+    updateChartPanOrZoom,
     viewAfter,
     viewBefore,
   })
@@ -421,10 +422,11 @@ export const DygraphChart = ({
     propsRef.current.globalChartUnderlay = globalChartUnderlay
     propsRef.current.resetGlobalPanAndZoom = resetGlobalPanAndZoom
     propsRef.current.setGlobalChartUnderlay = setGlobalChartUnderlay
+    propsRef.current.updateChartPanOrZoom = updateChartPanOrZoom
     propsRef.current.viewAfter = viewAfter
     propsRef.current.viewBefore = viewBefore
   }, [chartData, globalChartUnderlay, hoveredX, resetGlobalPanAndZoom,
-    setGlobalChartUnderlay, viewAfter, viewBefore])
+    setGlobalChartUnderlay, updateChartPanOrZoom, viewAfter, viewBefore])
 
   const shouldSmoothPlot = useSelector(selectSmoothPlot)
   useLayoutEffect(() => {
@@ -497,13 +499,13 @@ export const DygraphChart = ({
             if (isInRangeOfAvailableData({
               after, before, chartData: propsRef.current.chartData,
             })) {
-              updateChartPanOrZoom({ after, before })
+              propsRef.current.updateChartPanOrZoom({ after, before })
             }
           }
         },
         zoomCallback: (minDate: number, maxDate: number) => {
           latestIsUserAction.current = true
-          updateChartPanOrZoom({ after: minDate, before: maxDate })
+          propsRef.current.updateChartPanOrZoom({ after: minDate, before: maxDate })
         },
 
         underlayCallback(canvas: CanvasRenderingContext2D, area: DygraphArea, g: Dygraph) {
@@ -721,7 +723,7 @@ export const DygraphChart = ({
 
               const [after, before] = zoomRange(dygraph, percentage, xPct, yPct)
 
-              updateChartPanOrZoom({
+              propsRef.current.updateChartPanOrZoom({
                 after,
                 before,
                 shouldNotExceedAvailableRange: true,

--- a/src/domains/chart/components/lib-charts/sparkline-chart.tsx
+++ b/src/domains/chart/components/lib-charts/sparkline-chart.tsx
@@ -21,10 +21,10 @@ interface TimeWindowCorrection {
   widthRatio?: number
 }
 const getForceTimeWindowCorrection = (
-  chartData: EasyPieChartData, requestedViewRange: TimeRange,
+  chartData: EasyPieChartData, viewRange: TimeRange,
 ): TimeWindowCorrection => {
-  const requestedAfter = convertToTimestamp(requestedViewRange[0])
-  const requestedBefore = convertToTimestamp(requestedViewRange[1])
+  const requestedAfter = convertToTimestamp(viewRange[0])
+  const requestedBefore = convertToTimestamp(viewRange[1])
   const after = chartData.after * MS_IN_SECOND
   const before = chartData.before * MS_IN_SECOND
 
@@ -59,7 +59,8 @@ interface Props {
   isRemotelyControlled: boolean
   orderedColors: string[]
   unitsCurrent: string
-  requestedViewRange: TimeRange
+  viewAfterForCurrentData: number,
+  viewBeforeForCurrentData: number,
 }
 export const SparklineChart = ({
   attributes,
@@ -70,7 +71,8 @@ export const SparklineChart = ({
   chartElementId,
   orderedColors,
   unitsCurrent,
-  requestedViewRange,
+  viewAfterForCurrentData,
+  viewBeforeForCurrentData,
 }: Props) => {
   const chartElement = useRef<HTMLDivElement>(null)
 
@@ -79,7 +81,7 @@ export const SparklineChart = ({
   const sparklineOptions = useRef<{[key: string]: any}>()
 
   const { paddingLeftPercentage = undefined, widthRatio = 1 } = attributes.forceTimeWindow
-    ? getForceTimeWindowCorrection(chartData, requestedViewRange)
+    ? getForceTimeWindowCorrection(chartData, [viewAfterForCurrentData, viewBeforeForCurrentData])
     : {}
 
   // create chart

--- a/src/domains/chart/reducer.test.ts
+++ b/src/domains/chart/reducer.test.ts
@@ -1,0 +1,60 @@
+import { chartReducer, initialState } from "./reducer"
+import { fetchDataAction } from "./actions"
+
+const chart1ID = "chart1ID"
+
+describe("chart reducer", () => {
+  describe("fetchDataAction.success", () => {
+    it("keeps unchanged values after update", () => {
+      expect(true).toBe(true)
+      const fetchDataParams = {}
+      const result1 = chartReducer(initialState, fetchDataAction.success({
+        chartData: {
+          dimension_names: ["dim1", "dim2"],
+          result: ["val1", "val2"],
+        },
+        fetchDataParams,
+        id: chart1ID,
+      }))
+      const result2 = chartReducer(result1, fetchDataAction.success({
+        chartData: {
+          dimension_names: ["dim1", "dim2"],
+          result: ["val3", "val4"],
+        },
+        fetchDataParams,
+        id: chart1ID,
+      }))
+      expect(
+        result1[chart1ID].chartData!.dimension_names,
+      ).toBe(
+        result2[chart1ID].chartData!.dimension_names,
+      )
+    })
+
+    it("replaces changed values after update", () => {
+      expect(true).toBe(true)
+      const fetchDataParams = {}
+      const result1 = chartReducer(initialState, fetchDataAction.success({
+        chartData: {
+          dimension_names: ["dim1", "dim2"],
+          result: ["val1", "val2"],
+        },
+        fetchDataParams,
+        id: chart1ID,
+      }))
+
+      const newDimensionNames = ["dim1", "dim3"]
+      const result2 = chartReducer(result1, fetchDataAction.success({
+        chartData: {
+          dimension_names: newDimensionNames,
+          result: ["val3", "val4"],
+        },
+        fetchDataParams,
+        id: chart1ID,
+      }))
+      expect(
+        result2[chart1ID].chartData!.dimension_names,
+      ).toBe(newDimensionNames)
+    })
+  })
+})

--- a/src/domains/chart/reducer.ts
+++ b/src/domains/chart/reducer.ts
@@ -6,6 +6,7 @@ import { createReducer } from "redux-act"
 import { setOptionAction } from "domains/global/actions"
 import { SYNC_PAN_AND_ZOOM } from "domains/global/options"
 
+import { isTimestamp } from "utils"
 import {
   fetchDataAction,
   fetchChartAction,
@@ -43,6 +44,7 @@ export const initialSingleState = {
   snapshotDataIsFetching: false,
   snapshotDataIsError: false,
   snapshotData: null,
+  viewRange: null,
 }
 
 export const chartReducer = createReducer<StateT>(
@@ -52,12 +54,13 @@ export const chartReducer = createReducer<StateT>(
 
 const getSubstate = (state: StateT, id: string) => state[id] || initialSingleState
 
-chartReducer.on(fetchDataAction.request, (state, { chart, id }) => ({
+chartReducer.on(fetchDataAction.request, (state, { chart, fetchDataParams, id }) => ({
   ...state,
   [id]: {
     ...getSubstate(state, id),
     chartId: chart,
     isFetchingData: true,
+    viewRange: fetchDataParams.viewRange,
   },
 }))
 
@@ -86,6 +89,7 @@ chartReducer.on(fetchDataAction.success, (state, { id, chartData, fetchDataParam
     fetchDataParams,
     isFetchingData: false,
     isFetchDataFailure: false,
+    viewRange: fetchDataParams.viewRange,
   },
 }))
 

--- a/src/domains/chart/reducer.ts
+++ b/src/domains/chart/reducer.ts
@@ -6,7 +6,6 @@ import { createReducer } from "redux-act"
 import { setOptionAction } from "domains/global/actions"
 import { SYNC_PAN_AND_ZOOM } from "domains/global/options"
 
-import { isTimestamp } from "utils"
 import {
   fetchDataAction,
   fetchChartAction,

--- a/src/domains/chart/selectors.ts
+++ b/src/domains/chart/selectors.ts
@@ -40,7 +40,7 @@ export const makeSelectChartMetadataRequest = () => createSelector(
 
 export const selectChartViewRange = createSelector(
   selectSingleChartState,
-  (chartState) => chartState.fetchDataParams.viewRange,
+  (chartState) => chartState.viewRange,
 )
 
 export const selectChartIsFetchingData = createSelector(

--- a/src/domains/global/reducer.ts
+++ b/src/domains/global/reducer.ts
@@ -311,16 +311,9 @@ globalReducer.on(setGlobalSelectionAction, (state, { chartUuid, hoveredX }) => (
 
 globalReducer.on(
   setGlobalPanAndZoomAction,
-  (state, {
-    after, before, masterID, shouldForceTimeRange,
-  }) => ({
+  (state, payload) => ({
     ...state,
-    globalPanAndZoom: {
-      after,
-      before,
-      masterID,
-      shouldForceTimeRange,
-    },
+    globalPanAndZoom: payload,
   }),
 )
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { equals } from "ramda"
+
 // we use numbers to specify time. it can be either a timestamp (ms), or a relative value in seconds
 // which is always 0 or less (0 is now, -300 is -5 minutes)
 
@@ -25,3 +27,15 @@ export const getInitialAfterFromWindow = () => {
 }
 
 export const SPACE_PANEL_STATE = "space-panel-state"
+
+export const useNewKeysOnlyIfDifferent = <T extends {}>(
+  keys: (keyof T)[], obj1: T | null, obj2: T,
+): T => {
+  if (!obj1) {
+    return obj2
+  }
+  return keys.reduce<T>((acc, key) => ({
+    ...acc,
+    [key]: equals(obj1[key], obj2![key]) ? obj1[key] : obj2[key],
+  }), obj2)
+}


### PR DESCRIPTION
I've changed the way we update dygraph during panning.

- we always keep "requested" timeframe instead of timeframe that we get from data - so consecutive requests don't trigger when request for "similar" timeframe is already pending
- similar to the old dashboard, when user pans we debounce the requests until user pauses for 400 ms or there's a mouse-up event
- i've added a separate dependency - "useDebouncedCallback" from "use-debounce" hook that works much better than the one from "react-use" library, because it doesn't introduce a separate state, instead it works only on callbacks
- improved few memoizations, especially `dimensions` and `colours`, preventing some unnecessary updates