### PR TITLE
fix chart heights for new legend

### DIFF
--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -397,6 +397,7 @@ export const Chart = memo(({
       chartContainerElement={chartContainerElement}
       chartUuid={chartUuid}
       heightId={attributes.heightId}
+      isLegendOnBottom={isLegendOnBottom}
     />
   )
 

--- a/src/domains/chart/components/resize-handler.tsx
+++ b/src/domains/chart/components/resize-handler.tsx
@@ -24,9 +24,6 @@ export const ResizeHandler = ({ chartContainerElement, chartUuid, heightId }: Pr
           resizeHeight,
         }),
       )
-      if (heightId) {
-        localStorage.setItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX}${heightId}`, `${resizeHeight}px`)
-      }
     }
   }, [resizeHeight, chartUuid, heightId, dispatch])
 
@@ -43,6 +40,9 @@ export const ResizeHandler = ({ chartContainerElement, chartUuid, heightId }: Pr
         // eslint-disable-next-line no-param-reassign
         chartContainerElement.style.height = `${nextHeight.toString()}px`
         setResizeHeight(nextHeight)
+        if (heightId) {
+          localStorage.setItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX}${heightId}`, `${nextHeight}px`)
+        }
       }
 
       const onMouseMove = (e: MouseEvent) => setHeight(e.clientY)
@@ -66,7 +66,7 @@ export const ResizeHandler = ({ chartContainerElement, chartUuid, heightId }: Pr
         document.addEventListener("mouseup", onMouseEnd)
       }
     },
-    [chartContainerElement],
+    [chartContainerElement, heightId],
   )
 
   return (

--- a/src/domains/chart/components/resize-handler.tsx
+++ b/src/domains/chart/components/resize-handler.tsx
@@ -1,17 +1,22 @@
 import React, { useState, useCallback, useEffect } from "react"
 import { ToolboxButton } from "domains/chart/components/toolbox-button"
 import { setResizeHeightAction } from "domains/chart/actions"
+import { LEGEND_BOTTOM_SINGLE_LINE_HEIGHT } from "domains/chart/utils/legend-utils"
 import { useDispatch } from "store/redux-separate-context"
 
-export const LOCALSTORAGE_HEIGHT_KEY_PREFIX = "chart_heights."
+export const LOCALSTORAGE_HEIGHT_KEY_PREFIX_OLD = "chart_heights."
+export const LOCALSTORAGE_HEIGHT_KEY_PREFIX = "chart_height."
 
 interface Props {
   chartContainerElement: HTMLElement
   chartUuid: string
   heightId: string | undefined
+  isLegendOnBottom: boolean
 }
 
-export const ResizeHandler = ({ chartContainerElement, chartUuid, heightId }: Props) => {
+export const ResizeHandler = ({
+  chartContainerElement, chartUuid, heightId, isLegendOnBottom,
+}: Props) => {
   const [resizeHeight, setResizeHeight] = useState(() => chartContainerElement.clientHeight)
   const dispatch = useDispatch()
 
@@ -41,7 +46,13 @@ export const ResizeHandler = ({ chartContainerElement, chartUuid, heightId }: Pr
         chartContainerElement.style.height = `${nextHeight.toString()}px`
         setResizeHeight(nextHeight)
         if (heightId) {
-          localStorage.setItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX}${heightId}`, `${nextHeight}px`)
+          const heightForPersistance = isLegendOnBottom
+            ? (nextHeight - LEGEND_BOTTOM_SINGLE_LINE_HEIGHT)
+            : nextHeight
+          localStorage.setItem(
+            `${LOCALSTORAGE_HEIGHT_KEY_PREFIX}${heightId}`,
+            `${heightForPersistance}`,
+          )
         }
       }
 
@@ -66,7 +77,8 @@ export const ResizeHandler = ({ chartContainerElement, chartUuid, heightId }: Pr
         document.addEventListener("mouseup", onMouseEnd)
       }
     },
-    [chartContainerElement, heightId],
+    [chartContainerElement.clientHeight, chartContainerElement.style.height, heightId,
+      isLegendOnBottom],
   )
 
   return (

--- a/src/domains/chart/utils/get-portal-node-styles.ts
+++ b/src/domains/chart/utils/get-portal-node-styles.ts
@@ -1,5 +1,9 @@
-import { LOCALSTORAGE_HEIGHT_KEY_PREFIX } from "domains/chart/components/resize-handler"
+import {
+  LOCALSTORAGE_HEIGHT_KEY_PREFIX,
+  LOCALSTORAGE_HEIGHT_KEY_PREFIX_OLD,
+} from "domains/chart/components/resize-handler"
 
+import { LEGEND_BOTTOM_SINGLE_LINE_HEIGHT } from "domains/chart/utils/legend-utils"
 import { Attributes } from "./transformDataAttributes"
 import { ChartLibraryConfig } from "./chartLibrariesSettings"
 
@@ -11,6 +15,23 @@ type GetPortalNodeStyles = (
   width: string | undefined,
   minWidth: string | undefined
 }
+
+const getHeightFromLocalStorage = (heightID: string, isLegendOnBottom: boolean) => {
+  const persitedHeight = localStorage.getItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX}${heightID}`)
+  if (persitedHeight) {
+    if (Number.isNaN(Number(persitedHeight))) {
+      return null
+    }
+    return `${isLegendOnBottom
+      ? Number(persitedHeight) + LEGEND_BOTTOM_SINGLE_LINE_HEIGHT
+      : persitedHeight
+    }px`
+  }
+  // we'll support the old key for few months, so user custom heights will be working
+  // but we'll save any changes to new key only
+  return localStorage.getItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX_OLD}${heightID}`)
+}
+
 export const getPortalNodeStyles: GetPortalNodeStyles = (
   attributes,
   chartSettings,
@@ -31,9 +52,10 @@ export const getPortalNodeStyles: GetPortalNodeStyles = (
       height = `${attributes.height.toString()}px`
     }
   }
+  const isLegendOnBottom = attributes.legendPosition === "bottom"
 
   const heightFromLocalStorage = attributes.heightId
-    ? localStorage.getItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX}${attributes.heightId}`)
+    ? getHeightFromLocalStorage(attributes.heightId, isLegendOnBottom)
     : null
 
   if (heightFromLocalStorage) {

--- a/src/domains/chart/utils/get-portal-node-styles.ts
+++ b/src/domains/chart/utils/get-portal-node-styles.ts
@@ -16,6 +16,8 @@ type GetPortalNodeStyles = (
   minWidth: string | undefined
 }
 
+const oldDefaultHeights = ["180px", "90px"]
+
 const getHeightFromLocalStorage = (heightID: string, isLegendOnBottom: boolean) => {
   const persitedHeight = localStorage.getItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX}${heightID}`)
   if (persitedHeight) {
@@ -27,9 +29,22 @@ const getHeightFromLocalStorage = (heightID: string, isLegendOnBottom: boolean) 
       : persitedHeight
     }px`
   }
-  // we'll support the old key for few months, so user custom heights will be working
-  // but we'll save any changes to new key only
-  return localStorage.getItem(`${LOCALSTORAGE_HEIGHT_KEY_PREFIX_OLD}${heightID}`)
+
+  // We'll support the old key for few months, so that user's custom heights will be working,
+  // but we'll save any changes only to the new key.
+  const persistedHeightOld = localStorage.getItem(
+    `${LOCALSTORAGE_HEIGHT_KEY_PREFIX_OLD}${heightID}`,
+  )
+  if (persistedHeightOld) {
+    if (oldDefaultHeights.includes(persistedHeightOld)) {
+      // If saved value looks like `oldDefaultHeights`, then it is most likely an automatic value
+      // from old dashboard. Don't import it anymore. On next resize the height will be persisted
+      // to the new key.
+      return null
+    }
+    return persistedHeightOld
+  }
+  return null
 }
 
 export const getPortalNodeStyles: GetPortalNodeStyles = (


### PR DESCRIPTION
Old Dashboard was persisting heights of all charts to localStorage, even if they haven't been changed by the user. Now, if users open the dashboard with new legends, that persisted height will be set to both chart+legend, resulting in much smaller, hard-to-read charts. Unfortunately we don't know if that height was set in old dashboard, new dashboard or new dashboard with legend-on-bottom.

![image](https://user-images.githubusercontent.com/5786722/102662967-278b6c00-4180-11eb-8ad6-2f734f809904.png)


To minimize the "inconvenience", i've added a detection of old-dashboard properties, that will not enforce the height of old default values, ie. 180px and 90px. We omit that height in this case.
I've also changed a key for that property (with a read-fallback for old one), so that now when we persist, we save the height adjusted by current legend-position setting. In the future when we'll toggle this legend-position setting, the chart heights will be almost the same.
Additionally, I changed the persistence setting to save only when resize is happening, not on chart-mount.
