### PR TITLE
fix dygraph's iframes overlapping

### DIFF
--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -42,6 +42,7 @@ import { selectResizeHeight } from "../../selectors"
 
 import {
   getDygraphChartType, getDataForFakeStacked, transformColors, getDygraphFillAlpha,
+  hackDygraphIFrameTarps,
 } from "./dygraph/utils"
 import "./dygraph-chart.css"
 
@@ -546,6 +547,10 @@ export const DygraphChart = ({
             latestIsUserAction.current = true
             isMouseDown.current = true
             context.initializeMouseDown(event, dygraph, context)
+
+            // limit problematic dygraph's feature, more info above the function
+            // eslint-disable-next-line no-param-reassign
+            context.tarp.tarps = hackDygraphIFrameTarps(context.tarp.tarps)
 
             if (event.button && event.button === 1) {
               // middle mouse button

--- a/src/domains/chart/components/lib-charts/dygraph/utils.ts
+++ b/src/domains/chart/components/lib-charts/dygraph/utils.ts
@@ -84,3 +84,20 @@ export const getDygraphFillAlpha = (
   : dygraphChartType === "stacked"
     ? window.NETDATA.options.current.color_fill_opacity_stacked
     : window.NETDATA.options.current.color_fill_opacity_area)
+
+
+// https://github.com/danvk/dygraphs/blob/master/src/iframe-tarp.js#L1-L23
+// On mouseUp dygraphs put rectangles above all iframes so mouseUp can be properly intercepted.
+// this causes a problem with some analytics iframes that place themselves in regions where they
+// aren't visible anyway (for example hubspot iframe on Cloud), and this creates a problematic
+// horizontal scrollbar to appear. This function filters those "rectangles" (tarps) to omit
+// elements with unreachable "left" styles
+export const hackDygraphIFrameTarps = (tarps: HTMLDivElement[]): HTMLDivElement[] => (
+  tarps.filter((element: HTMLDivElement) => {
+    const isOutsideReasonableViewport = Number(element.style.left.replace("px", "")) > 10000
+    if (isOutsideReasonableViewport) {
+      element.parentNode!.removeChild(element)
+    }
+    return !isOutsideReasonableViewport
+  })
+)


### PR DESCRIPTION
fix problematic dygraph's feature, to limit "overlapping" of third-party iframes, which causes unwanted scrollbar on panning

![image](https://user-images.githubusercontent.com/5786722/103667011-aac90200-4f75-11eb-9a1a-7401d653965b.png)
