### PR TITLE
fix composite-charts with low-history gauge charts data handling

### DIFF
--- a/src/utils/fill-missing-data.ts
+++ b/src/utils/fill-missing-data.ts
@@ -97,6 +97,8 @@ export const transformResults = (data: ChartData, format: string, shouldRevertFl
       : (data as DygraphData).result.data
     return {
       ...data,
+      // set proper output type so other functions like fillMissingData work properly
+      format: "array",
       result: dataResult.reduce((acc: number[], pointData: number[]) => {
         pointData.shift()
         return [


### PR DESCRIPTION
Fix situation when unsuficcient-history combined with composite-charts results with gauge charts data calls handling error.