### PR TITLE
overview grouping issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/chart/chart-types.ts
+++ b/src/domains/chart/chart-types.ts
@@ -96,6 +96,7 @@ export interface ChartMetadata {
 export interface ChartEnriched extends ChartMetadata {
   menu: string
   menu_pattern: string
+  sectionTitle: string
   submenu: string
 }
 

--- a/src/domains/dashboard/utils/netdata-dashboard.ts
+++ b/src/domains/dashboard/utils/netdata-dashboard.ts
@@ -146,6 +146,9 @@ export const netdataDashboard = {
   },
 
   menuTitle(chart: ChartEnriched) {
+    if (chart.sectionTitle) {
+      return chart.sectionTitle
+    }
     if (typeof chart.menu_pattern !== "undefined") {
       const type = chart.type || chart.id.split(".")[0]
       return (`${this.anyAttribute(this.menu, "title", chart.menu_pattern, chart.menu_pattern)

--- a/src/domains/dashboard/utils/render-charts-and-menu.ts
+++ b/src/domains/dashboard/utils/render-charts-and-menu.ts
@@ -49,6 +49,13 @@ function enrichChartData(chartName: string, chart: ChartMetadata, hasKubernetes:
         || chartEnriched.id.match(/.*[._/-:]kvm[._/-:]*/)
       ) {
         chartEnriched.menu_pattern = "cgqemu"
+      } else if (parts.length === 1) {
+        // composite-charts
+        // override complex title generation in menuTitle()
+        // We cannot change it in dashboard_info.js because it needs to be dynamic,
+        // ie. when used for k8s dashboard-info.js' title should be still an empty string
+        chartEnriched.sectionTitle = "cgroups"
+        chartEnriched.menu_pattern = "cgroup"
       } else {
         chartEnriched.menu_pattern = "cgroup"
       }

--- a/src/domains/dashboard/utils/render-charts-and-menu.ts
+++ b/src/domains/dashboard/utils/render-charts-and-menu.ts
@@ -85,6 +85,17 @@ function enrichChartData(chartName: string, chart: ChartMetadata, hasKubernetes:
       }
       break
 
+    case "prometheus": {
+      if (parts.length === 1) {
+        // composite-charts
+        const familyPart = chart.family.split("_")[0]
+        chartEnriched.menu = `prometheus ${familyPart}`
+      } else {
+        chartEnriched.menu_pattern = "prometheus"
+      }
+      break
+    }
+
     case "smartd":
     case "web":
       if (parts.length > 2 && parts[1] === "log") {


### PR DESCRIPTION
https://github.com/netdata/netdata-cloud/issues/25

- use "cgroups" instead of buggy "group" name for cgroups section (override group title when overview is detected)
- group prometheus charts by job name