### PR TITLE
alarms-log-export-fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1974,7 +1974,7 @@ function alarmsUpdateModal() {
                 searchAlign: 'left',
                 showColumns: true,
                 showExport: true,
-                exportDataType: 'basic',
+                exportDataType: 'all',
                 exportOptions: {
                     fileName: 'netdata_alarm_log'
                 },

--- a/src/main.js
+++ b/src/main.js
@@ -1679,11 +1679,13 @@ function alarmsUpdateModal() {
             }
 
             var t = new Date(timestamp * 1000);
-            var now = new Date();
 
-            if (t.toDateString() === now.toDateString()) {
-                return t.toLocaleTimeString();
-            }
+            // commented out to always have date+time, to have consistent exports
+            // var now = new Date();
+
+            // if (t.toDateString() === now.toDateString()) {
+            //     return t.toLocaleTimeString();
+            // }
 
             return t.toLocaleDateString() + space + t.toLocaleTimeString();
         }


### PR DESCRIPTION
- use all pages when exporting alarms log 
- always use date+time in alarms log, so when it's exported we have all information (bootstrap-table doesn't allow changing formatting for view and export)

<img width="1435" alt="obraz" src="https://user-images.githubusercontent.com/5786722/107373655-0f342f80-6ae7-11eb-8a62-04354024a56d.png">
