### PR TITLE
persist relative timeframe in agent

### DIFF
--- a/src/components/date-picker/redux-wrapped-picker.tsx
+++ b/src/components/date-picker/redux-wrapped-picker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 
 import { useDispatch, useSelector } from "store/redux-separate-context"
 import { selectGlobalPanAndZoom, selectDefaultAfter } from "domains/global/selectors"
@@ -53,6 +53,17 @@ export const ReduxWrappedPicker = ({ tagging }: Props) => {
       )
     }
   }
+
+  useEffect(() => {
+    const { start, end } = pickedValues
+    if (window.urlOptions) {
+      if (window.urlOptions.after !== start || window.urlOptions.before !== end) {
+        const isPanAndZoom = start > 0
+        window.urlOptions.netdataPanAndZoomCallback(isPanAndZoom, start, end)
+      }
+    }
+  }, [pickedValues])
+
   return (
     <Picker
       isOpen={isOpen}

--- a/src/domains/dashboard/sagas.ts
+++ b/src/domains/dashboard/sagas.ts
@@ -5,11 +5,8 @@ import { Action } from "redux-act"
 
 import {
   clearHighlightAction,
-  resetGlobalPanAndZoomAction,
   SetGlobalChartUnderlayAction,
   setGlobalChartUnderlayAction,
-  SetGlobalPanAndZoomAction,
-  setGlobalPanAndZoomAction,
 } from "domains/global/actions"
 import {
   explicitlySignInAction,
@@ -19,35 +16,6 @@ import {
 import { setHashParams, getHashParams, removeHashParams } from "utils/hash-utils"
 
 export const LOCAL_STORAGE_NEEDS_SYNC = "LOCAL-STORAGE-NEEDS-SYNC"
-
-function setGlobalPanAndZoomSaga({ payload }: Action<SetGlobalPanAndZoomAction>) {
-  const { after, before } = payload
-  if (window.urlOptions) {
-    // additional check to prevent loop, after setting initial state from url
-    if (window.urlOptions.after !== after || window.urlOptions.before !== before) {
-      window.urlOptions.netdataPanAndZoomCallback(true, after, before)
-    }
-  }
-  // TODO: Set hash params also for window?
-  // else {
-  //   const hashParams = getHashParams()
-  //   const afterString = Math.round(after).toString()
-  //   const beforeString = Math.round(before).toString()
-  //   if (hashParams.after !== afterString || hashParams.before !== beforeString) {
-  //     setHashParams({ after: afterString, before: beforeString })
-  //   }
-  // }
-}
-
-function resetGlobalPanAndZoomSaga() {
-  if (window.urlOptions) {
-    window.urlOptions.netdataPanAndZoomCallback(false, 0, 0)
-  }
-  // TODO: Set hash params also for window?
-  // else {
-  //   removeHashParams(["after", "before"])
-  // }
-}
 
 function setGlobalChartUnderlaySaga({ payload }: Action<SetGlobalChartUnderlayAction>) {
   const { after, before } = payload
@@ -90,8 +58,6 @@ function* showSignInSaga({ payload }: Action<ShowSignInModalAction>) {
 }
 
 export function* mainJsSagas() {
-  yield takeEvery(setGlobalPanAndZoomAction, setGlobalPanAndZoomSaga)
-  yield takeEvery(resetGlobalPanAndZoomAction, resetGlobalPanAndZoomSaga)
   yield takeEvery(setGlobalChartUnderlayAction, setGlobalChartUnderlaySaga)
   yield takeEvery(clearHighlightAction, clearHighlightSaga)
   yield takeEvery(showSignInModalAction, showSignInSaga)

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import {
     resetGlobalPanAndZoomAction,
     resetOptionsAction,
     resetRegistry,
+    setDefaultAfterAction,
     setGlobalChartUnderlayAction,
     setGlobalPanAndZoomAction,
     setOptionAction,
@@ -141,10 +142,8 @@ window.urlOptions = {
     genHash: function (forReload) {
         var hash = urlOptions.hash;
 
-        if (urlOptions.pan_and_zoom === true) {
-            hash += ';after=' + urlOptions.after.toString() +
-              ';before=' + urlOptions.before.toString();
-        }
+        hash += ';after=' + urlOptions.after.toString() +
+          ';before=' + urlOptions.before.toString();
 
         if (urlOptions.highlight === true) {
             hash += ';highlight_after=' + urlOptions.highlight_after.toString() +
@@ -3960,22 +3959,20 @@ function runOnceOnDashboardWithjQuery() {
 }
 
 function finalizePage() {
-    // resize all charts - without starting the background thread
-    // this has to be done while NETDATA is paused
-    // if we ommit this, the affix menu will be wrong, since all
-    // the Dom elements are initially zero-sized
-    NETDATA.parseDom();
-
-    // ------------------------------------------------------------------------
-
-    if (urlOptions.pan_and_zoom === true) {
+    if (urlOptions.after < 0) {
+        reduxStore.dispatch(setDefaultAfterAction({ after: urlOptions.after }))
+    } else if (urlOptions.pan_and_zoom === true) {
         reduxStore.dispatch(setGlobalPanAndZoomAction({
             after: urlOptions.after,
             before: urlOptions.before,
         }))
     }
 
-    // ------------------------------------------------------------------------
+    // resize all charts - without starting the background thread
+    // this has to be done while NETDATA is paused
+    // if we ommit this, the affix menu will be wrong, since all
+    // the Dom elements are initially zero-sized
+    NETDATA.parseDom();
 
     // let it run (update the charts)
     NETDATA.unpause();


### PR DESCRIPTION
Persist relative timeframe (negative "after") in url.
Because that url dependes on 2 separate states (globalPanAndZoom, defaultAfter), i moved the logic out of sagas to redux-wrapped-picker, so it's working simlarly to cloud now.