### PR TITLE
fix demo - datepicker overlap

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -77,36 +77,35 @@
         <div id="navbar-highlight-content" class="navbar-highlight-content"></div>
     </div>
 
-    <div id="masthead" style="display: none;">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-7">
-                    <h1>Netdata
-                        <p class="lead">Real-time performance monitoring, in the greatest possible detail</p>
-                    </h1>
-                </div>
-                <div class="col-md-5">
-                    <div class="well well-lg">
+    <div class="container">
+        <div class="row">
+            <div class="charts-body" role="main">
+                <div id="masthead" style="display: none;">
+                    <div class="container">
                         <div class="row">
-                        <div class="col-md-6">
-                            <b>Drag</b> charts to pan.
-                            <b>Shift + wheel</b> on them, to zoom in and out.
-                            <b>Double-click</b> on them, to reset.
-                            <b>Hover</b> on them too!
+                            <div class="col-md-7">
+                                <h1>Netdata
+                                    <p class="lead">Real-time performance monitoring, in the greatest possible detail</p>
+                                </h1>
                             </div>
-                        <div class="col-md-6">
-                            <div class="netdata-container" data-netdata="system.intr" data-chart-library="dygraph" data-dygraph-theme="sparkline" data-dygraph-type="line" data-dygraph-strokewidth="3" data-dygraph-smooth="true" data-dygraph-highlightcirclesize="6" data-after="-90" data-height="60px" data-colors="#C66"></div>
+                            <div class="col-md-5">
+                                <div class="well well-lg">
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <b>Drag</b> charts to pan.
+                                            <b>Shift + wheel</b> on them, to zoom in and out.
+                                            <b>Double-click</b> on them, to reset.
+                                            <b>Hover</b> on them too!
+                                        </div>
+                                        <div class="col-md-6">
+                                            <div class="netdata-container" data-netdata="system.cpu" data-dimensions="user" data-chart-library="dygraph" data-dygraph-theme="sparkline" data-dygraph-type="line" data-dygraph-strokewidth="3" data-dygraph-smooth="true" data-dygraph-highlightcirclesize="6" data-after="-90" data-height="60px" data-colors="#C66"></div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="container">
-        <div class="row">
-            <div class="charts-body" role="main">
                 <div id="charts_div"></div>
             </div>
             <div class="sidebar-body hidden-xs hidden-sm hidden-print" id="sidebar-body" role="complementary">

--- a/src/main.js
+++ b/src/main.js
@@ -3713,7 +3713,7 @@ function runOnceOnDashboardWithjQuery() {
     $('#sidebar')
         .affix({
             offset: {
-                top: (isDemo) ? 150 : 0,
+                top: 0,
                 bottom: 0
             }
         })


### PR DESCRIPTION
move "demo" info above charts, without so that right side with date-picker and menu stays intact and doesn't overlap

from:
<img width="636" alt="obraz" src="https://user-images.githubusercontent.com/5786722/108401348-891d9480-721c-11eb-8c85-3c766ec5d7cc.png">

to:
<img width="727" alt="obraz" src="https://user-images.githubusercontent.com/5786722/108401370-8de24880-721c-11eb-9528-d2d85a3bd2b5.png">
