### PR TITLE
fix lint warnings to unblock release build

### DIFF
--- a/src/domains/chart/components/chart-legend-right.tsx
+++ b/src/domains/chart/components/chart-legend-right.tsx
@@ -8,7 +8,7 @@ import { useDateTime } from "utils/date-time"
 
 import { legendResolutionTooltip, legendPluginModuleString } from "../utils/legend-utils"
 
-import { ChartMetadata, DygraphData } from "../chart-types"
+import { ChartMetadata } from "../chart-types"
 
 interface Props {
   chartUuid: string

--- a/src/domains/chart/components/chart-legend.tsx
+++ b/src/domains/chart/components/chart-legend.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "store/redux-separate-context"
 import { selectChartData } from "domains/chart/selectors"
 import { getNewSelectedDimensions } from "domains/chart/utils/legend-utils"
 import { Attributes } from "../utils/transformDataAttributes"
-import { ChartMetadata, DygraphData } from "../chart-types"
+import { ChartMetadata } from "../chart-types"
 
 import { ChartLegendRight } from "./chart-legend-right"
 import { ChartLegendBottom } from "./chart-legend-bottom"

--- a/src/domains/chart/components/chart.tsx
+++ b/src/domains/chart/components/chart.tsx
@@ -30,7 +30,7 @@ import { getPanAndZoomStep } from "../utils/get-pan-and-zoom-step"
 import { Attributes } from "../utils/transformDataAttributes"
 import { chartLibrariesSettings } from "../utils/chartLibrariesSettings"
 import { useFormatters } from "../utils/formatters"
-import { ChartData, ChartMetadata, DygraphData } from "../chart-types"
+import { ChartData, ChartMetadata } from "../chart-types"
 
 import { ChartLegend } from "./chart-legend"
 import { LegendToolbox } from "./legend-toolbox"


### PR DESCRIPTION
Unfortunately lint warnings blocked the release build

> Treating warnings as errors because process.env.CI = true.
> Most CI servers set it automatically.
