### PR TITLE
alarm-overlays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.13.30",
+  "version": "2.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,13 +1676,14 @@
       }
     },
     "@netdata/netdata-ui": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@netdata/netdata-ui/-/netdata-ui-1.2.16.tgz",
-      "integrity": "sha512-tL0vrh4puXJ0ta6fOvXgLNzasznyC4Mdnjv0ku5nAEzaxGmCcVMeQEl+rTz5LFGzfSFLXUK2laxYBIQjfTshoA==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@netdata/netdata-ui/-/netdata-ui-1.3.10.tgz",
+      "integrity": "sha512-YGueFess/+ivPSi/CFhFqnAxM7kigluwbPEevnRqeMZ17AqiCOJamqcFIol3J6wykUEUp7sUjGKHhD24gnbCVg==",
       "requires": {
         "@netdata/react-filter-box": "^1.0.0",
         "polished": "^4.0.3",
         "ramda": "^0.27.1",
+        "react-beautiful-dnd": "^13.0.0",
         "react-portal": "^4.2.0",
         "react-table": "^7.2.1",
         "react-use": "^15.3.4",
@@ -1751,9 +1752,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -2013,11 +2014,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@rmwc/types/-/types-5.6.0.tgz",
       "integrity": "sha512-fTH6ZSGxIs5DYj05925y4EPDRdcu4lBtBGJ3iRjP0+lXB6qYyY1Zgp0Fgc/ubgv3fEGsfKcJR9QvaYsW6g18aA=="
-    },
-    "@scarf/scarf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.1.0.tgz",
-      "integrity": "sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg=="
     },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.2",
@@ -5265,9 +5261,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codemirror": {
-      "version": "5.59.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.2.tgz",
-      "integrity": "sha512-/D5PcsKyzthtSy2NNKCyJi3b+htRkoKv3idswR/tR6UAvMNKA7SrmyZy6fOONJxSRs1JlUWEDAbxqfdArbK8iA=="
+      "version": "5.59.4",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.4.tgz",
+      "integrity": "sha512-achw5JBgx8QPcACDDn+EUUXmCYzx/zxEtOGXyjvLEvYY8GleUrnfm5D+Zb+UjShHggXKDT9AXrbkBZX6a0YSQg=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -6371,6 +6367,14 @@
       "integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
       "requires": {
         "postcss": "^7.0.5"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-color-names": {
@@ -13474,18 +13478,17 @@
       }
     },
     "polished": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.0.tgz",
-      "integrity": "sha512-y8IInTGHuwku7+O+wsJ7OOvNpJF7EPP/IDzF1uj9UJfEEKpMAfeq5gZ5UrtOksM7Jk4+hBAk6Ce8rFOOF4msZg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.1.tgz",
+      "integrity": "sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@scarf/scarf": "^1.1.0"
+        "@babel/runtime": "^7.12.5"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -14784,6 +14787,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz",
+      "integrity": "sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ=="
+    },
     "railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -14975,6 +14983,35 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz",
+      "integrity": "sha512-87It8sN0ineoC3nBW0SbQuTFXM6bUqM62uJGY4BtTf0yzPl8/3+bHMWkgIe0Z6m8e+gJgjWxefGRVfpE3VcdEg==",
+      "requires": {
+        "@babel/runtime": "^7.8.4",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.1.1",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "react-codemirror2": {
@@ -17853,6 +17890,11 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -18331,6 +18373,11 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-5.2.0.tgz",
       "integrity": "sha512-lW4tbPsTnvPKYqOYXp5xZ7SP7No/ARLqqQqoyRKuSzP0HxR9arhSAhznXUZFoNPWDRij8fog+N6sYbjb8c3kzw=="
+    },
+    "use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.13.30",
+  "version": "2.14.0",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@material/list": "^4.0.0",
     "@material/menu": "^2.3.0",
     "@material/menu-surface": "^1.0.0",
-    "@netdata/netdata-ui": "^1.2.16",
+    "@netdata/netdata-ui": "^1.3.10",
     "@rmwc/icon": "^5.7.2",
     "@rmwc/list": "^5.7.2",
     "@rmwc/menu": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { PrintModal } from "domains/dashboard/components/print-modal"
 import { SidebarSocialMedia } from "domains/dashboard/components/sidebar-social-media"
 import { SidebarSocialMediaPortal } from "domains/dashboard/components/sidebar-social-media-portal"
 import { isPrintMode } from "domains/dashboard/utils/parse-url"
+import useAlarmFromUrl from "domains/dashboard/hooks/useAlarmFromUrl"
 import { useRegistry } from "hooks/use-registry"
 import { useListenToFocusMessages } from "hooks/use-listen-to-focus-messages"
 import { useAlarms } from "hooks/use-alarms"
@@ -146,6 +147,7 @@ const App: React.FC = () => {
 
   const hasFetchedInfo = useSelector(selectHasFetchedInfo)
   const theme = useSelector(selectTheme)
+  useAlarmFromUrl()
 
   return (
     <ThemeProvider theme={mapTheme(theme)}>

--- a/src/domains/chart/components/disable-out-of-view.tsx
+++ b/src/domains/chart/components/disable-out-of-view.tsx
@@ -6,7 +6,7 @@ import { forEachObjIndexed } from "ramda"
 
 import { useDispatch, useSelector } from "store/redux-separate-context"
 import { isPrintMode } from "domains/dashboard/utils/parse-url"
-import { selectDestroyOnHide, selectIsAsyncOnScroll } from "domains/global/selectors"
+import { selectDestroyOnHide, selectIsAsyncOnScroll, selectAlarm } from "domains/global/selectors"
 import { getPortalNodeStyles } from "domains/chart/utils/get-portal-node-styles"
 import { Attributes } from "domains/chart/utils/transformDataAttributes"
 import { chartLibrariesSettings } from "domains/chart/utils/chartLibrariesSettings"
@@ -65,12 +65,12 @@ export const DisableOutOfView = ({
   /* separate functionality - adding custom styles to portalNode */
   const chartSettings = chartLibrariesSettings[attributes.chartLibrary]
   const [hasPortalNodeBeenStyled, setHasPortalNodeBeenStyled] = useState<boolean>(false)
-  // todo omit this for Cloud
+  const shouldAddSpecialHeight = useSelector(selectAlarm)?.chart === attributes.id
   useLayoutEffect(() => {
     if (hasPortalNodeBeenStyled) {
       return
     }
-    const styles = getPortalNodeStyles(attributes, chartSettings)
+    const styles = getPortalNodeStyles(attributes, chartSettings, shouldAddSpecialHeight)
     forEachObjIndexed((value, styleName) => {
       if (value) {
         portalNode.style.setProperty(styleName, value)
@@ -79,7 +79,8 @@ export const DisableOutOfView = ({
     // eslint-disable-next-line no-param-reassign
     portalNode.className = chartSettings.containerClass(attributes)
     setHasPortalNodeBeenStyled(true)
-  }, [attributes, chartSettings, hasPortalNodeBeenStyled, portalNode, setHasPortalNodeBeenStyled])
+  }, [attributes, chartSettings, hasPortalNodeBeenStyled, portalNode, setHasPortalNodeBeenStyled,
+    shouldAddSpecialHeight])
   /* end of "adding custom styles to portalNode" */
 
 

--- a/src/domains/chart/components/disable-out-of-view.tsx
+++ b/src/domains/chart/components/disable-out-of-view.tsx
@@ -65,11 +65,14 @@ export const DisableOutOfView = ({
   /* separate functionality - adding custom styles to portalNode */
   const chartSettings = chartLibrariesSettings[attributes.chartLibrary]
   const [hasPortalNodeBeenStyled, setHasPortalNodeBeenStyled] = useState<boolean>(false)
-  const shouldAddSpecialHeight = useSelector(selectAlarm)?.chart === attributes.id
+  const isShowingAlarmOnChart = useSelector(selectAlarm)?.chart === attributes.id
   useLayoutEffect(() => {
     if (hasPortalNodeBeenStyled) {
       return
     }
+    const shouldAddSpecialHeight = isShowingAlarmOnChart
+      && attributes.chartLibrary === "dygraph"
+      && chartSettings.hasLegend(attributes)
     const styles = getPortalNodeStyles(attributes, chartSettings, shouldAddSpecialHeight)
     forEachObjIndexed((value, styleName) => {
       if (value) {
@@ -79,8 +82,8 @@ export const DisableOutOfView = ({
     // eslint-disable-next-line no-param-reassign
     portalNode.className = chartSettings.containerClass(attributes)
     setHasPortalNodeBeenStyled(true)
-  }, [attributes, chartSettings, hasPortalNodeBeenStyled, portalNode, setHasPortalNodeBeenStyled,
-    shouldAddSpecialHeight])
+  }, [attributes, chartSettings, hasPortalNodeBeenStyled, isShowingAlarmOnChart, portalNode,
+    setHasPortalNodeBeenStyled ])
   /* end of "adding custom styles to portalNode" */
 
 

--- a/src/domains/chart/components/disable-out-of-view.tsx
+++ b/src/domains/chart/components/disable-out-of-view.tsx
@@ -65,7 +65,7 @@ export const DisableOutOfView = ({
   /* separate functionality - adding custom styles to portalNode */
   const chartSettings = chartLibrariesSettings[attributes.chartLibrary]
   const [hasPortalNodeBeenStyled, setHasPortalNodeBeenStyled] = useState<boolean>(false)
-  const isShowingAlarmOnChart = useSelector(selectAlarm)?.chart === attributes.id
+  const isShowingAlarmOnChart = useSelector(selectAlarm)?.chartId === attributes.id
   useLayoutEffect(() => {
     if (hasPortalNodeBeenStyled) {
       return

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -1,23 +1,26 @@
 import React, { forwardRef } from "react"
 import styled from "styled-components"
 
-export const getBackgroundColor = (status) => ({
+const backgroundColorMap = {
   WARNING: "#FFF8E1",
   CRITICAL: "#FFEBEF",
   CLEAR: "#E5F5E8",
-})[status] || null
+}
+export const getBackgroundColor = (status) => backgroundColorMap[status] || null
 
-export const getBorderColor = (status) => ({
+const borderColorMap = {
   WARNING: "#FFC300",
   CRITICAL: "#F59B9B",
   CLEAR: "#68C47D",
-})[status] || null
+}
+export const getBorderColor = (status) => borderColorMap[status] || null
 
-export const getColor = (status) => ({
+const textColorMap = {
   WARNING: "#536775",
   CRITICAL: "#FF4136",
   CLEAR: "#00AB44",
-})[status] || null
+}
+export const getColor = (status) => textColorMap[status] || null
 
 const Container = styled.div`
   position: absolute;

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -39,7 +39,7 @@ const Badge = styled.div`
 `
 
 export default forwardRef((
-  { alarm: { status, value }},
+  { status, label },
   ref,
 ) => (
   <Container ref={ref}>
@@ -48,7 +48,7 @@ export default forwardRef((
       border={getBorderColor(status)}
       color={getColor(status)}
     >
-      {value}
+      {label}
     </Badge>
   </Container>
 ))

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -1,0 +1,52 @@
+import React, { forwardRef } from "react"
+import styled from "styled-components"
+
+export const getBackgroundColor = (status) => ({
+  WARNING: "#FFF8E1",
+  CRITICAL: "#FFEBEF",
+  CLEAR: "#E5F5E8",
+})[status] || null
+
+export const getBorderColor = (status) => ({
+  WARNING: "#FFC300",
+  CRITICAL: "#F59B9B",
+  CLEAR: "#68C47D",
+})[status] || null
+
+export const getColor = (status) => ({
+  WARNING: "#536775",
+  CRITICAL: "#FF4136",
+  CLEAR: "#00AB44",
+})[status] || null
+
+const Container = styled.div`
+  position: absolute;
+  margin-right: 10px;
+  overflow: hidden;
+  pointer-events: none;
+`
+
+const Badge = styled.div`
+  border-radius: 36px;
+  padding: 2px 12px;
+  background: ${({ background }) => background};
+  border: 1px solid ${({ border }) => border};
+  color: ${({ color }) => color};
+  font-size: 12px;
+  font-weight: 700;
+`
+
+export default forwardRef((
+  { alarm: { status, value }},
+  ref,
+) => (
+  <Container ref={ref} >
+    <Badge
+      background={getBackgroundColor(status)}
+      border={getBorderColor(status)}
+      color={getColor(status)}
+    >
+      {value}
+    </Badge>
+  </Container>
+))

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -24,9 +24,11 @@ const Container = styled.div`
   margin-right: 10px;
   overflow: hidden;
   pointer-events: none;
+  direction: rtl;
 `
 
 const Badge = styled.div`
+  display: inline-block;
   border-radius: 36px;
   padding: 2px 12px;
   background: ${({ background }) => background};
@@ -40,7 +42,7 @@ export default forwardRef((
   { alarm: { status, value }},
   ref,
 ) => (
-  <Container ref={ref} >
+  <Container ref={ref}>
     <Badge
       background={getBackgroundColor(status)}
       border={getBorderColor(status)}

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -1134,7 +1134,7 @@ export const DygraphChart = ({
       )}
       {alarm && hasLegend && (
         // @ts-ignore
-        <AlarmBadge ref={alarmBadgeRef} alarm={alarm} />
+        <AlarmBadge ref={alarmBadgeRef} status={alarm.status} label={alarm.value} />
       )}
       <div className="dygraph-chart__labels-hidden" id={hiddenLabelsElementId} />
     </>

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -48,7 +48,7 @@ import {
 import "./dygraph-chart.css"
 
 import useProceededChart from "../../hooks/use-proceeded-chart"
-import useAlarmBadge from "../../hooks/useAlarmBadge"
+import useDygraphBadge from "../../hooks/useDygraphBadge"
 import ProceededChartDisclaimer from "./proceeded-chart-disclaimer"
 import AlarmBadge, { getBorderColor } from "./alarmBadge"
 
@@ -404,7 +404,7 @@ export const DygraphChart = ({
     }
   }, [chartUuid, dispatch, isSyncPanAndZoom])
 
-  const [isAlarmBadge, alarmBadgeRef, updateAlarmBadge] = useAlarmBadge() as any
+  const [isAlarmBadge, alarmBadgeRef, updateAlarmBadge] = useDygraphBadge() as any
 
   // setGlobalChartUnderlay is using state from closure (chartData.after), so we need to have always
   // the newest callback. Unfortunately we cannot use Dygraph.updateOptions() (library restriction)

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -335,7 +335,7 @@ export const DygraphChart = ({
 }: Props) => {
   const globalChartUnderlay = useSelector(selectGlobalChartUnderlay)
   const selectedAlarm = useSelector(selectAlarm)
-  const alarm = selectedAlarm?.chart === chartData.id ? selectedAlarm : null
+  const alarm = selectedAlarm?.chartId === chartData.id ? selectedAlarm : null
 
   const { xAxisDateString, xAxisTimeString } = useDateTime()
   const chartSettings = chartLibrariesSettings[chartLibrary]
@@ -404,7 +404,7 @@ export const DygraphChart = ({
     }
   }, [chartUuid, dispatch, isSyncPanAndZoom])
 
-  const [isAlarmBadge, alarmBadgeRef, updateAlarmBadge] = useDygraphBadge() as any
+  const [, alarmBadgeRef, updateAlarmBadge] = useDygraphBadge() as any
 
   // setGlobalChartUnderlay is using state from closure (chartData.after), so we need to have always
   // the newest callback. Unfortunately we cannot use Dygraph.updateOptions() (library restriction)

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -532,17 +532,15 @@ export const DygraphChart = ({
             const alarmPosition = g.toDomXCoord(currentAlarm.when * 1000)
             const fillColor = getBorderColor(currentAlarm.status)
 
-            if (fillColor) {
-              const horizontalPadding = 3
-              canvas.fillStyle = fillColor
-              canvas.fillRect(alarmPosition - horizontalPadding, area.y, 2 * horizontalPadding, area.h)
+            const horizontalPadding = 3
+            canvas.fillStyle = fillColor
+            canvas.fillRect(alarmPosition - horizontalPadding, area.y, 2 * horizontalPadding, area.h)
 
-              propsRef.current.updateAlarmBadge(
-                propsRef.current.alarm,
-                g,
-                alarmPosition - horizontalPadding,
-              )
-            }
+            propsRef.current.updateAlarmBadge(
+              propsRef.current.alarm,
+              g,
+              alarmPosition - horizontalPadding,
+            )
           }
 
           // the chart is about to be drawn

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -48,7 +48,9 @@ import {
 import "./dygraph-chart.css"
 
 import useProceededChart from "../../hooks/use-proceeded-chart"
+import useAlarmBadge from "../../hooks/useAlarmBadge"
 import ProceededChartDisclaimer from "./proceeded-chart-disclaimer"
+import AlarmBadge, { getBorderColor } from "./alarmBadge"
 
 // This is the threshold above which we assume chart shown duration has changed
 const timeframeThreshold = 5000
@@ -402,6 +404,8 @@ export const DygraphChart = ({
     }
   }, [chartUuid, dispatch, isSyncPanAndZoom])
 
+  const [isAlarmBadge, alarmBadgeRef, updateAlarmBadge] = useAlarmBadge() as any
+
   // setGlobalChartUnderlay is using state from closure (chartData.after), so we need to have always
   // the newest callback. Unfortunately we cannot use Dygraph.updateOptions() (library restriction)
   // for interactionModel callbacks so we need to keep the callback in mutable ref
@@ -414,6 +418,7 @@ export const DygraphChart = ({
     // put it to ref to prevent additional updateOptions() after creating dygraph
     resetGlobalPanAndZoom,
     setGlobalChartUnderlay,
+    updateAlarmBadge,
     updateChartPanOrZoom,
     viewAfter,
     viewBefore,
@@ -431,11 +436,12 @@ export const DygraphChart = ({
     propsRef.current.globalChartUnderlay = globalChartUnderlay
     propsRef.current.resetGlobalPanAndZoom = resetGlobalPanAndZoom
     propsRef.current.setGlobalChartUnderlay = setGlobalChartUnderlay
+    propsRef.current.updateAlarmBadge = updateAlarmBadge
     propsRef.current.updateChartPanOrZoom = updateChartPanOrZoom
     propsRef.current.viewAfter = viewAfter
     propsRef.current.viewBefore = viewBefore
-  }, [chartData, globalChartUnderlay, hoveredX, immediatelyDispatchPanAndZoom,
-    resetGlobalPanAndZoom, setGlobalChartUnderlay, updateChartPanOrZoom, viewAfter, viewBefore])
+  }, [alarm, chartData, globalChartUnderlay, hoveredX, immediatelyDispatchPanAndZoom,
+    resetGlobalPanAndZoom, setGlobalChartUnderlay, updateAlarmBadge, updateChartPanOrZoom, viewAfter, viewBefore])
 
   const shouldSmoothPlot = useSelector(selectSmoothPlot)
   useLayoutEffect(() => {
@@ -530,6 +536,12 @@ export const DygraphChart = ({
               const horizontalPadding = 3
               canvas.fillStyle = fillColor
               canvas.fillRect(alarmPosition - horizontalPadding, area.y, 2 * horizontalPadding, area.h)
+
+              propsRef.current.updateAlarmBadge(
+                propsRef.current.alarm,
+                g,
+                alarmPosition - horizontalPadding,
+              )
             }
           }
 
@@ -1119,6 +1131,10 @@ export const DygraphChart = ({
       />
       {isProceeded && hasLegend && (
         <ProceededChartDisclaimer ref={precededChartRef as React.Ref<HTMLDivElement>} />
+      )}
+      {alarm && hasLegend && (
+        // @ts-ignore
+        <AlarmBadge ref={alarmBadgeRef} alarm={alarm} />
       )}
       <div className="dygraph-chart__labels-hidden" id={hiddenLabelsElementId} />
     </>

--- a/src/domains/chart/hooks/useAlarmBadge.js
+++ b/src/domains/chart/hooks/useAlarmBadge.js
@@ -18,7 +18,9 @@ export default () => {
       if (!isRendered) {
         toggleIsRendered(true)
       }
+      const { x } = g.getArea()
 
+      ref.current.style.left = `${x}px`
       ref.current.style.right = `calc(100% - ${position}px)`
       ref.current.style.top = "40px"
     }

--- a/src/domains/chart/hooks/useAlarmBadge.js
+++ b/src/domains/chart/hooks/useAlarmBadge.js
@@ -8,16 +8,12 @@ export default () => {
 
   const updatePosition = (alarm, g, position) => {
     if (!alarm) {
-      if (isRendered) {
-        toggleIsRendered(false)
-      }
+      toggleIsRendered(false)
       return
     }
 
     if (ref.current) {
-      if (!isRendered) {
-        toggleIsRendered(true)
-      }
+      toggleIsRendered(true)
       const { x } = g.getArea()
 
       ref.current.style.left = `${x}px`

--- a/src/domains/chart/hooks/useAlarmBadge.js
+++ b/src/domains/chart/hooks/useAlarmBadge.js
@@ -1,0 +1,28 @@
+import { useRef } from "react"
+import { useToggle } from "react-use"
+
+export default () => {
+  const [isRendered, toggleIsRendered] = useToggle(false)
+
+  const ref = useRef(null)
+
+  const updatePosition = (alarm, g, position) => {
+    if (!alarm) {
+      if (isRendered) {
+        toggleIsRendered(false)
+      }
+      return
+    }
+
+    if (ref.current) {
+      if (!isRendered) {
+        toggleIsRendered(true)
+      }
+
+      ref.current.style.right = `calc(100% - ${position}px)`
+      ref.current.style.top = "40px"
+    }
+  }
+
+  return [isRendered, ref, updatePosition]
+}

--- a/src/domains/chart/hooks/useDygraphBadge.js
+++ b/src/domains/chart/hooks/useDygraphBadge.js
@@ -1,13 +1,15 @@
 import { useRef } from "react"
 import { useToggle } from "react-use"
 
+const badgeTopMargin = "40px"
+
 export default () => {
   const [isRendered, toggleIsRendered] = useToggle(false)
 
   const ref = useRef(null)
 
-  const updatePosition = (alarm, g, position) => {
-    if (!alarm) {
+  const updatePosition = (isVisible, g, position) => {
+    if (!isVisible) {
       toggleIsRendered(false)
       return
     }
@@ -18,7 +20,7 @@ export default () => {
 
       ref.current.style.left = `${x}px`
       ref.current.style.right = `calc(100% - ${position}px)`
-      ref.current.style.top = "40px"
+      ref.current.style.top = badgeTopMargin
     }
   }
 

--- a/src/domains/chart/utils/get-portal-node-styles.ts
+++ b/src/domains/chart/utils/get-portal-node-styles.ts
@@ -10,6 +10,7 @@ import { ChartLibraryConfig } from "./chartLibrariesSettings"
 type GetPortalNodeStyles = (
   attributes: Attributes,
   chartSettings: ChartLibraryConfig,
+  shouldAddSpecialHeight: boolean,
 ) => {
   height: string | undefined,
   width: string | undefined,
@@ -50,6 +51,7 @@ const getHeightFromLocalStorage = (heightID: string, isLegendOnBottom: boolean) 
 export const getPortalNodeStyles: GetPortalNodeStyles = (
   attributes,
   chartSettings,
+  shouldAddSpecialHeight,
 ) => {
   let width
   if (typeof attributes.width === "string") {
@@ -78,6 +80,13 @@ export const getPortalNodeStyles: GetPortalNodeStyles = (
     // JSON.stringify when setting localStorage so many users have '"180px"' values set.
     // We can remove .replace() after some time
     height = heightFromLocalStorage.replace(/"/g, "")
+  }
+
+  if (shouldAddSpecialHeight) {
+    const heightOverriden = isLegendOnBottom
+      ? window.innerHeight * 0.5
+      : window.innerHeight * 0.4
+    height = `${heightOverriden}px`
   }
 
   const chartDefaultsMinWidth = window.NETDATA.chartDefaults.min_width

--- a/src/domains/dashboard/hooks/useAlarmFromUrl.js
+++ b/src/domains/dashboard/hooks/useAlarmFromUrl.js
@@ -1,0 +1,35 @@
+import { useMount } from "react-use"
+
+import { useDispatch } from "store/redux-separate-context"
+import { getHashParams } from "utils/hash-utils"
+import { setAlarmAction, setGlobalPanAndZoomAction } from "domains/global/actions"
+
+export default () => {
+  const dispatch = useDispatch()
+  useMount(() => {
+    const params = getHashParams()
+    const alarmWhen = params["alarm_when"]
+    if (alarmWhen) {
+      const alarmTime = Number(alarmWhen)
+
+      const alarmStatus = params["alarm_status"]
+      const alarmChart = params["alarm_chart"]
+      const alarmValue = params["alarm_value"]
+
+      dispatch(setAlarmAction({
+        alarm: {
+          chart: alarmChart || "system.load",
+          // @ts-ignore
+          status: alarmStatus,
+        value: alarmValue,
+        when: alarmTime,
+        },
+      }))
+      const PADDING = 1000 * 60 * 5
+      dispatch(setGlobalPanAndZoomAction({
+        after: alarmTime * 1000 - PADDING,
+        before: alarmTime * 1000 + PADDING,
+      }))
+    }
+  })
+}

--- a/src/domains/dashboard/hooks/useAlarmFromUrl.js
+++ b/src/domains/dashboard/hooks/useAlarmFromUrl.js
@@ -3,6 +3,7 @@ import { useMount } from "react-use"
 import { useDispatch } from "store/redux-separate-context"
 import { getHashParams } from "utils/hash-utils"
 import { setAlarmAction, setGlobalPanAndZoomAction } from "domains/global/actions"
+import { alarmStatuses } from "domains/global/constants"
 
 export default () => {
   const dispatch = useDispatch()
@@ -15,6 +16,9 @@ export default () => {
       const alarmStatus = params["alarm_status"]
       const alarmChart = params["alarm_chart"]
       const alarmValue = params["alarm_value"]
+      if (!alarmStatuses.includes(alarmStatus) || !alarmChart || !alarmValue) {
+        return
+      }
 
       dispatch(setAlarmAction({
         alarm: {

--- a/src/domains/dashboard/hooks/useAlarmFromUrl.js
+++ b/src/domains/dashboard/hooks/useAlarmFromUrl.js
@@ -22,8 +22,7 @@ export default () => {
 
       dispatch(setAlarmAction({
         alarm: {
-          chart: alarmChart,
-          // @ts-ignore
+          chartId: alarmChart,
           status: alarmStatus,
           value: alarmValue,
           when: alarmTime,

--- a/src/domains/dashboard/hooks/useAlarmFromUrl.js
+++ b/src/domains/dashboard/hooks/useAlarmFromUrl.js
@@ -18,11 +18,11 @@ export default () => {
 
       dispatch(setAlarmAction({
         alarm: {
-          chart: alarmChart || "system.load",
+          chart: alarmChart,
           // @ts-ignore
           status: alarmStatus,
-        value: alarmValue,
-        when: alarmTime,
+          value: alarmValue,
+          when: alarmTime,
         },
       }))
       const PADDING = 1000 * 60 * 5

--- a/src/domains/global/actions.ts
+++ b/src/domains/global/actions.ts
@@ -3,7 +3,7 @@ import { createAction } from "redux-act"
 import { createRequestAction } from "utils/createRequestAction"
 import { RegistryMachine } from "domains/global/sagas"
 import { storeKey } from "./constants"
-import { ActiveAlarms, ChartsMetadata, Snapshot } from "./types"
+import { ActiveAlarms, ChartsMetadata, Snapshot, Alarm } from "./types"
 
 interface RequestCommonColors {
   chartContext: string
@@ -148,5 +148,7 @@ export interface SetSpacePanelTransitionEndPayload {
 export const setSpacePanelTransitionEndAction = createAction<SetSpacePanelTransitionEndPayload>(
   `${storeKey}/setSpacePanelStatusAction`,
 )
+
+export const setAlarmAction = createAction<{ alarm: Alarm }>(`${storeKey}/setAlarmAction`)
 
 export const resetRegistry = createAction(`${storeKey}/resetRegistry`)

--- a/src/domains/global/constants.ts
+++ b/src/domains/global/constants.ts
@@ -1,3 +1,5 @@
+import { AlarmStatus } from "domains/global/types"
+
 export const storeKey = "global"
 
 export const TEMPORARY_MAIN_JS_TIMEOUT = 1000
@@ -9,3 +11,5 @@ export const NOTIFICATIONS_TIMEOUT = 5000
 export const INFO_POLLING_FREQUENCY = 5000
 
 export const CLOUD_BASE_URL_DISABLED = "CLOUD_BASE_URL_DISABLED"
+
+export const alarmStatuses: AlarmStatus[] = ["WARNING", "ERROR", "REMOVED", "UNDEFINED", "UNINITIALIZED", "CLEAR", "CRITICAL"]

--- a/src/domains/global/reducer.ts
+++ b/src/domains/global/reducer.ts
@@ -4,7 +4,7 @@ import { createReducer } from "redux-act"
 import { getInitialAfterFromWindow } from "utils/utils"
 import { isMainJs } from "utils/env"
 import { RegistryMachine } from "domains/global/sagas"
-import { ActiveAlarms, Snapshot, ChartsMetadata } from "domains/global/types"
+import { Alarm, ActiveAlarms, Snapshot, ChartsMetadata } from "domains/global/types"
 import { fetchInfoAction } from "domains/chart/actions"
 import { InfoPayload } from "./__mocks__/info-mock"
 import {
@@ -32,6 +32,7 @@ import {
   resetRegistry,
   accessRegistrySuccessAction,
   resetDefaultAfterAction,
+  setAlarmAction,
 } from "./actions"
 import {
   Options, optionsMergedWithLocalStorage, getOptionsMergedWithLocalStorage, clearLocalStorage,
@@ -112,6 +113,7 @@ export type StateT = {
     activeAlarms: null | ActiveAlarms
     hasStartedAlarms: boolean
   }
+  alarm: null | Alarm
 
   snapshot: Snapshot | null
   options: Options
@@ -159,6 +161,7 @@ export const initialState: StateT = {
     activeAlarms: null,
     hasStartedAlarms: false,
   },
+  alarm: null,
 
   chartsMetadata: {
     isFetching: false,
@@ -556,6 +559,10 @@ globalReducer.on(loadSnapshotAction, (state, { snapshot }) => {
   }
 })
 
+globalReducer.on(setAlarmAction, (state, { alarm }) => ({
+  ...state,
+  alarm,
+}))
 
 globalReducer.on(chartsMetadataRequestSuccess, (state, { data }) => ({
   ...state,

--- a/src/domains/global/selectors.ts
+++ b/src/domains/global/selectors.ts
@@ -97,6 +97,11 @@ export const selectActiveAlarms = createSelector(
   (global) => global.alarms.activeAlarms,
 )
 
+export const selectAlarm = createSelector(
+  selectGlobal,
+  (global) => global.alarm
+)
+
 export const selectSpacePanelIsActive = createSelector(selectGlobal, prop("spacePanelIsActive"))
 export const selectSpacePanelTransitionEndIsActive = createSelector(
   selectGlobal, prop("spacePanelTransitionEndIsActive"),

--- a/src/domains/global/types.ts
+++ b/src/domains/global/types.ts
@@ -43,9 +43,9 @@ export interface AlarmLog {
 export type AlarmLogs = AlarmLog[]
 
 export type Alarm = {
-  chart?: string
-  value?: string
-  status?: AlarmStatus
+  chartId: string
+  value: string
+  status: AlarmStatus
   when: number
 }
 

--- a/src/domains/global/types.ts
+++ b/src/domains/global/types.ts
@@ -2,6 +2,7 @@
 
 import { ChartMetadata } from "domains/chart/chart-types"
 
+export type AlarmStatus = "WARNING" | "ERROR" | "REMOVED" | "UNDEFINED" | "UNINITIALIZED" | "CLEAR" | "CRITICAL"
 // it's possible that this interface is too narrow
 export interface AlarmLog {
   hostname: string
@@ -24,8 +25,8 @@ export interface AlarmLog {
   duration: number
   no_clear_notification?: boolean
   non_clear_duration: number
-  status: string
-  old_status: string
+  status: AlarmStatus
+  old_status: AlarmStatus
   delay: number
   delay_up_to_timestamp: number
   updated_by_id: number
@@ -35,11 +36,18 @@ export interface AlarmLog {
   last_repeat: string
   silenced: string
   info: string
-  value: null
-  old_value: null
+  value: number
+  old_value: number
 }
 
 export type AlarmLogs = AlarmLog[]
+
+export type Alarm = {
+  chart?: string
+  value?: string
+  status?: AlarmStatus
+  when: number
+}
 
 interface Alarms {
   [id: string]: {

--- a/src/index-npm.ts
+++ b/src/index-npm.ts
@@ -48,12 +48,14 @@ export {
   clearHighlightAction,
   setSpacePanelTransitionEndAction,
   setDefaultAfterAction,
+  setAlarmAction,
 } from "domains/global/actions"
 export {
   selectStopUpdatesWhenFocusIsLost,
   selectDestroyOnHide,
   selectDefaultAfter,
   selectGlobalPanAndZoom,
+  selectAlarm,
 } from "domains/global/selectors"
 export { selectChartData } from "domains/chart/selectors"
 export { STOP_UPDATES_WHEN_FOCUS_IS_LOST, DESTROY_ON_HIDE } from "domains/global/options"

--- a/src/index-npm.ts
+++ b/src/index-npm.ts
@@ -24,6 +24,7 @@ export {
 } from "store/redux-separate-context"
 export { store as dashboardStore } from "store"
 
+export { default as useAlarmFromUrl } from "domains/dashboard/hooks/useAlarmFromUrl"
 export { ChartContainer } from "domains/chart/components/chart-container"
 
 export { NodeView } from "domains/dashboard/components/node-view"

--- a/src/main.js
+++ b/src/main.js
@@ -129,10 +129,6 @@ window.urlOptions = {
     chart: null,
     family: null,
     alarm: null,
-    alarm_unique_id: 0,
-    alarm_id: 0,
-    alarm_event_id: 0,
-    alarm_when: 0,
 
     hasProperty: function (property) {
         // console.log('checking property ' + property + ' of type ' + typeof(this[property]));
@@ -199,7 +195,7 @@ window.urlOptions = {
             }
         }
 
-        var numeric = ['after', 'before', 'highlight_after', 'highlight_before', 'alarm_when'];
+        var numeric = ['after', 'before', 'highlight_after', 'highlight_before'];
         len = numeric.length;
         while (len--) {
             if (typeof urlOptions[numeric[len]] === 'string') {
@@ -211,22 +207,6 @@ window.urlOptions = {
                     urlOptions[numeric[len]] = 0;
                 }
             }
-        }
-
-        if (urlOptions.alarm_when) {
-            // if alarm_when exists, create after/before params
-            // -/+ 2 minutes from the alarm, and reload the page
-            const alarmTime = new Date(urlOptions.alarm_when * 1000).valueOf();
-            const timeMarginMs = 120000; // 2 mins
-
-            const after = alarmTime - timeMarginMs;
-            const before = alarmTime + timeMarginMs;
-            const newHash = document.location.hash.replace(
-              /;alarm_when=[0-9]*/i,
-              ";after=" + after + ";before=" + before,
-            );
-            history.replaceState(null, '', newHash);
-            location.reload();
         }
 
         if (urlOptions.server !== null && urlOptions.server !== '') {


### PR DESCRIPTION
Display a alarm overlay and a badge when dashboard is accessed with specific hash params.
Expose parts of it so cloud-fe can reuse it.

This is how it looks like, but most likely we'll be changing it in following iterations

<img width="561" alt="obraz" src="https://user-images.githubusercontent.com/5786722/110994899-cedfff80-8379-11eb-9200-a23abbd6679e.png">
