### PR TITLE
hash manipulation fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -28,6 +28,7 @@ const Container = styled.div`
   overflow: hidden;
   pointer-events: none;
   direction: rtl;
+  z-index: 10; // higher than chart
 `
 
 const Badge = styled.div`

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -44,16 +44,18 @@ const Badge = styled.div`
 `
 
 export default forwardRef((
-  { status, label },
+  { isVisible, status, label },
   ref,
 ) => (
   <Container ref={ref}>
-    <Badge
-      background={getBackgroundColor(status)}
-      border={getBorderColor(status)}
-      color={getColor(status)}
-    >
-      {label}
-    </Badge>
+    {isVisible && (
+      <Badge
+        background={getBackgroundColor(status)}
+        border={getBorderColor(status)}
+        color={getColor(status)}
+      >
+        {label}
+      </Badge>
+    )}
   </Container>
 ))

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -39,6 +39,7 @@ const Badge = styled.div`
   color: ${({ color }) => color};
   font-size: 12px;
   font-weight: 700;
+  direction: ltr;
 `
 
 export default forwardRef((

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -404,7 +404,7 @@ export const DygraphChart = ({
     }
   }, [chartUuid, dispatch, isSyncPanAndZoom])
 
-  const [, alarmBadgeRef, updateAlarmBadge] = useDygraphBadge() as any
+  const [isBadgeVisible, alarmBadgeRef, updateAlarmBadge] = useDygraphBadge() as any
 
   // setGlobalChartUnderlay is using state from closure (chartData.after), so we need to have always
   // the newest callback. Unfortunately we cannot use Dygraph.updateOptions() (library restriction)
@@ -1135,7 +1135,7 @@ export const DygraphChart = ({
       )}
       {alarm && hasLegend && (
         // @ts-ignore
-        <AlarmBadge ref={alarmBadgeRef} status={alarm.status} label={alarm.value} />
+        <AlarmBadge isVisible={isBadgeVisible} ref={alarmBadgeRef} status={alarm.status} label={alarm.value} />
       )}
       <div className="dygraph-chart__labels-hidden" id={hiddenLabelsElementId} />
     </>

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -531,10 +531,13 @@ export const DygraphChart = ({
 
             const alarmPosition = g.toDomXCoord(currentAlarm.when * 1000)
             const fillColor = getBorderColor(currentAlarm.status)
-
             const horizontalPadding = 3
-            canvas.fillStyle = fillColor
-            canvas.fillRect(alarmPosition - horizontalPadding, area.y, 2 * horizontalPadding, area.h)
+            // use RAF, because dygraph doesn't provide any callback called after drawing the chart
+            requestAnimationFrame(() => {
+              canvas.fillStyle = fillColor
+              canvas.globalAlpha = 0.7
+              canvas.fillRect(alarmPosition - horizontalPadding, area.y, 2 * horizontalPadding, area.h)
+            })
 
             propsRef.current.updateAlarmBadge(
               propsRef.current.alarm,

--- a/src/index-npm.ts
+++ b/src/index-npm.ts
@@ -35,6 +35,7 @@ export * from "domains/dashboard/components/node-view/use-update-theme"
 export * from "domains/dashboard/components/head-main"
 export { default as HeadMainContainer } from "domains/dashboard/components/headMainContainer"
 export * from "domains/dashboard/components/virtualized"
+export * from "utils/hash-utils"
 
 export * from "domains/charts"
 

--- a/src/utils/hash-utils.ts
+++ b/src/utils/hash-utils.ts
@@ -27,7 +27,9 @@ export const makeHashFromObject = (params: { [paramKey: string]: string }) => {
   if (entries.length === 0) {
     return ""
   }
-  return entries.map((entry) => entry.join("=")).join(fragmentParamsSeparator)
+  return entries.map(
+    ([key, value]) => `${key}=${encodeURIComponent(value)}`
+  ).join(fragmentParamsSeparator)
 }
 
 export const getFilteredHash = (

--- a/src/utils/hash-utils.ts
+++ b/src/utils/hash-utils.ts
@@ -3,7 +3,7 @@
 import { omit, pipe, mergeDeepLeft } from "ramda"
 
 type HashParams = { [param: string]: string }
-const fragmentParamsSeparatorRegEx = /[\s&;]/
+const fragmentParamsSeparatorRegEx = /[&;]/
 const fragmentParamsSeparator = ";"
 
 export const getHashParams = (


### PR DESCRIPTION
Don't split hash params by white-space, to fix problems with rich alarm values

Also added other changes that already are in cloud-frontend, and exposed them so we can avoid duplication.