### PR TITLE
Alarm template

### DIFF
--- a/src/email-templates/alert-notification/footer.mjml
+++ b/src/email-templates/alert-notification/footer.mjml
@@ -1,0 +1,7 @@
+<mj-section>
+    <mj-column>
+        <mj-text align="left">
+            © Netdata 2021 - The real-time performance and health monitoring
+        </mj-text>
+    </mj-column>
+</mj-section>

--- a/src/email-templates/alert-notification/footer.mjml
+++ b/src/email-templates/alert-notification/footer.mjml
@@ -1,7 +1,9 @@
-<mj-section>
-    <mj-column>
-        <mj-text align="left">
+<mj-section css-class="set-font">
+
+    <mj-column padding-top="44px" padding-bottom="12px">
+        <mj-text align="left" padding-top="0" padding-bottom="0">
             © Netdata 2021 - The real-time performance and health monitoring
         </mj-text>
     </mj-column>
+
 </mj-section>

--- a/src/email-templates/alert-notification/header.mjml
+++ b/src/email-templates/alert-notification/header.mjml
@@ -1,0 +1,5 @@
+<mj-section padding-bottom="50px">
+    <mj-column>
+        <mj-image padding-left="0" width="1000px" align="left" src="https://app.netdata.cloud/static/email/img/header.png" />
+    </mj-column>
+</mj-section>

--- a/src/email-templates/alert-notification/header.mjml
+++ b/src/email-templates/alert-notification/header.mjml
@@ -1,5 +1,10 @@
-<mj-section padding-bottom="50px">
-    <mj-column>
-        <mj-image padding-left="0" width="1000px" align="left" src="https://app.netdata.cloud/static/email/img/header.png" />
+<mj-section padding-bottom="50px" padding-left="0" text-align="left">
+    <mj-column width="130px">
+        <mj-image padding-left="0" padding-right="0" width="130px" src="https://app.netdata.cloud/static/email/img/full_logo.png" alt="Netdata Logo" />
+    </mj-column>
+    <mj-column padding-top="4px">
+        <mj-text padding-left="10px" font-size="16px" align="left">
+            Notification
+        </mj-text>
     </mj-column>
 </mj-section>

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -6,11 +6,11 @@
     />
     <mj-style>
       .value { background-color: pink; display: inline }
-      .link { color: #00AB44; text-decoration: none;  }
       .history-wrapper { max-width: 100% !important; }
     </mj-style>
     <mj-style inline="inline">
       .set-font { font-family: "IBM Plex Sans", sans-serif }
+      .link { color: #00AB44; text-decoration: none;  }
     </mj-style>
 
     <mj-attributes>
@@ -36,24 +36,22 @@
 
       <mj-section padding="0" css-class="set-font">
         <mj-column>
-          <mj-text align="left" font-family="IBM Plex Sans, sans-serif">on debian-2gb-nbdg1-1</mj-text>
+          <mj-text padding-top="0" align="left" font-family="IBM Plex Sans, sans-serif">on debian-2gb-nbdg1-1</mj-text>
         </mj-column>
       </mj-section>
 
       <mj-section css-class="set-font">
         <mj-column>
-          <mj-text align="left" font-size="26px" font-weight="700" padding-top="15px">
-            <mj-raw>
-              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
-              </span>
-            </mj-raw>
+          <mj-text align="left" font-size="26px" font-weight="700" padding-top="0">
+            <span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
+            </span>
           </mj-text>
         </mj-column>
       </mj-section>
 
       <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
         <mj-column>
-          <mj-text align="left">
+          <mj-text align="left" padding-top="0" font-size="16px" line-height="21px">
             Details: the percentage of time the disk was busy, during the last 10 minutes
           </mj-text>
         </mj-column>
@@ -61,12 +59,12 @@
 
       <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
         <mj-column width="50%">
-          <mj-button align="left" background-color="#FFFFFF" border="1px solid #FF4136" color="#FF4136" height="44px" width="100%">
+          <mj-button align="left" background-color="#FFFFFF" border="1px solid #FF4136" color="#FF4136" height="44px" width="100%" font-weight="600">
             RUN CORRELATIONS
           </mj-button>
         </mj-column>
         <mj-column width="50%">
-          <mj-button align="left" background-color="#FF4136" color="#ffffff" height="44px" width="100%">
+          <mj-button align="left" background-color="#FF4136" color="#ffffff" height="44px" width="100%" font-weight="600">
             GO TO CHART
           </mj-button>
         </mj-column>
@@ -74,7 +72,7 @@
 
       <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
         <mj-column width="100%">
-          <mj-button align="center" background-color="#FF4136" color="#ffffff" height="44px" width="100%" href="https://app.netdata.cloud">
+          <mj-button align="center" background-color="#FF4136" color="#ffffff" height="44px" width="100%" href="https://app.netdata.cloud" font-weight="600">
             GO TO CHART
           </mj-button>
         </mj-column>
@@ -86,37 +84,37 @@
 
     <mj-section background-color="#FFEBEF" css-class="set-font">
       <mj-column>
-        <mj-text align="left" font-size="18px">
+        <mj-text align="left" font-size="18px" padding-bottom="6px">
           Chart:
-          <mj-raw style="font-weight:700">disk.util</mj-raw>
+          <span style="font-weight:700">disk.util</span>
         </mj-text>
         <mj-text align="left" font-size="18px" padding-top="0">
           Family:
-          <mj-raw style="font-weight:700">8tb</mj-raw>
+          <span style="font-weight:700">8tb</span>
         </mj-text>
-        <mj-text align="left" font-size="14px">Escalated from Warning, raised for 5 minutes</mj-text>
+        <mj-text align="left" font-size="14px" padding-top="4px">Escalated from Warning, raised for 5 minutes</mj-text>
         <mj-divider border-width="1px" border-style="solid" border-color="lightgrey" />
 
-        <mj-text align="left" font-size="18px">
+        <mj-text align="left" font-size="16px" padding-bottom="6px">
           On
-          <mj-raw style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</mj-raw>
+          <span style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</span>
         </mj-text>
-        <mj-text align="left" font-size="18px" padding-top="0">
+        <mj-text align="left" font-size="16px" padding-top="0">
           By:
-          <mj-raw style="font-weight:500">{host name}</mj-raw>
+          <span style="font-weight:500">{host name}</span>
         </mj-text>
-        <mj-text align="left" font-size="14px">Global time:
-          <my-raw style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</my-raw>
+        <mj-text align="left" font-size="14px" padding-top="4px">Global time:
+          <span style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</span>
         </mj-text>
         <mj-divider border-width="1px" border-style="solid" border-color="lightgrey" />
 
-        <mj-text align="left" font-size="18px">
+        <mj-text align="left" font-size="16px" padding-bottom="6px">
           Classification:
-          <mj-raw style="font-weight:500">OS disk</mj-raw>
+          <span style="font-weight:500">OS disk</span>
         </mj-text>
-        <mj-text align="left" font-size="18px" padding-top="0">
+        <mj-text align="left" font-size="16px" padding-top="0">
           Role:
-          <mj-raw style="font-weight:500">sysadmin</mj-raw>
+          <span style="font-weight:500">sysadmin</span>
         </mj-text>
 
       </mj-column>
@@ -140,7 +138,7 @@
       </mj-column>
       <mj-column align="left" width="80%">
         <mj-text align="left" font-weight="700" font-size="16px">Need to configure this alert?</mj-text>
-        <mj-text align="left" font-size="14px" line-height="1.3"><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into {node} and running the following command:</mj-text>
+        <mj-text align="left" font-size="14px" line-height="1.3"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</mj-text>
         <mj-text align="left" font-size="12px" line-height="1.3" padding-top="8px">
           sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br />
           The alarm to edit is at line {160}
@@ -154,9 +152,9 @@
         <mj-column>
           <mj-text align="left" font-size="16px">
             The node has
-            <mj-raw style="font-weight:600">3 warnings</mj-raw>
+            <span style="font-weight:600">3 warnings</span>
             and
-            <mj-raw style="font-weight:600">0 critical</mj-raw>
+            <span style="font-weight:600">0 critical</span>
             alert(s)
           </mj-text>
         </mj-column>
@@ -165,7 +163,7 @@
       <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8" css-class="set-font">
         <mj-column>
           <mj-text align="left" font-size="14px" font-weight="600">10_m_response_time</mj-text>
-          <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
+          <mj-text align="left" font-size="12px" padding-top="2px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
         </mj-column>
         <mj-column padding-top="13px">
           <mj-text align="right">
@@ -179,7 +177,7 @@
       <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8" css-class="set-font">
         <mj-column>
           <mj-text align="left" font-size="14px" font-weight="600">10_m_response_time</mj-text>
-          <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
+          <mj-text align="left" font-size="12px" padding-top="2px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
         </mj-column>
         <mj-column padding-top="13px">
           <mj-text align="right">

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -10,7 +10,7 @@
     <mj-attributes>
       <mj-text align="center" color="#555" />
     </mj-attributes>
-    <mj-breakpoint width="200px" />
+    <mj-breakpoint width="100px" />
 
   </mj-head>
 
@@ -19,7 +19,7 @@
     <mj-include path="./header.mjml" />
 
     <mj-wrapper	border="1px solid #FF4136">
-      <mj-section padding-bottom="0">
+      <mj-section padding-bottom="0" padding-top="0">
         <mj-column width="70%">
           <mj-text align="left" font-size="20px" font-weight="700" padding-top="15px">10min_disk_utilization</mj-text>
         </mj-column>
@@ -53,15 +53,15 @@
         </mj-column>
       </mj-section>
 
-      <mj-section padding-top="0">
-        <mj-column>
+      <mj-section padding-top="0" padding-bottom="0">
+        <mj-column width="100%">
           <mj-button align="left" background-color="#FF4136" color="#ffffff" height="44px" width="100%">
             Go to Chart
           </mj-button>
         </mj-column>
-        <mj-column>
+        <mj-columne>
 
-        </mj-column>
+        </mj-columne>
       </mj-section>
 
     </mj-wrapper>
@@ -106,11 +106,11 @@
       </mj-column>
     </mj-section>
 
-    <mj-section>
-      <mj-column width="20%" align="left">
-        <mj-image align="center" src="https://app.netdata.cloud/static/email/img/community_icon.png" />
+    <mj-section padding-left="0">
+      <mj-column padding="0" width="100px">
+        <mj-image align="left" width="60px" src="https://app.netdata.cloud/static/email/img/community_icon.png" />
       </mj-column>
-      <mj-column align="left" width="60%">
+      <mj-column align="left" width="80%">
         <mj-text align="left" font-weight="700" font-size="16px">Want to know more about this alert?</mj-text>
         <mj-text align="left" font-size="14px" line-height="1.3">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></mj-text>
 
@@ -118,11 +118,11 @@
     </mj-section>
 
 
-    <mj-section>
-      <mj-column width="20%" align="left">
-        <mj-image align="left" src="https://app.netdata.cloud/static/email/img/configure_icon.png" widteeh="60px" />
+    <mj-section padding-left="0">
+      <mj-column padding="0" width="100px">
+        <mj-image align="left" src="https://app.netdata.cloud/static/email/img/configure_icon.png" width="60px" />
       </mj-column>
-      <mj-column align="left" width="60%">
+      <mj-column align="left" width="80%">
         <mj-text align="left" font-weight="700" font-size="16px">Need to configure this alert?</mj-text>
         <mj-text align="left" font-size="14px" line-height="1.3"><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into {node} and running the following command:</mj-text>
         <mj-text align="left" font-size="12px" line-height="1.3" padding-top="8px">
@@ -133,7 +133,7 @@
     </mj-section>
 
 
-    <mj-wrapper background-color="#F7F8F8" full-width padding="0" css-class="history-wrapper">
+    <mj-wrapper background-color="#F7F8F8" full-width padding="0" css-class="history-wrapper" padding-bottom="24px">
       <mj-section>
         <mj-column>
           <mj-text align="left" font-size="16px">
@@ -152,7 +152,7 @@
           <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
         </mj-column>
         <mj-column>
-          <mj-text><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+          <mj-text><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px;">
             Warning for 10m
           </mj-raw></mj-text>
         </mj-column>
@@ -164,7 +164,7 @@
           <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
         </mj-column>
         <mj-column>
-          <mj-text><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+          <mj-text><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
             Warning for 10m
           </mj-raw></mj-text>
         </mj-column>

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -1,10 +1,16 @@
 <mjml>
 
   <mj-head>
+    <mj-font name="IBM Plex Sans"
+             href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap"
+    />
     <mj-style>
       .value { background-color: pink; display: inline }
       .link { color: #00AB44; text-decoration: none;  }
       .history-wrapper { max-width: 100% !important; }
+    </mj-style>
+    <mj-style inline="inline">
+      .set-font { font-family: "IBM Plex Sans", sans-serif }
     </mj-style>
 
     <mj-attributes>
@@ -19,7 +25,7 @@
     <mj-include path="./header.mjml" />
 
     <mj-wrapper	border="1px solid #FF4136">
-      <mj-section padding-bottom="0" padding-top="0">
+      <mj-section padding-bottom="0" padding-top="0" css-class="set-font">
         <mj-column width="70%">
           <mj-text align="left" font-size="20px" font-weight="700" padding-top="15px">10min_disk_utilization</mj-text>
         </mj-column>
@@ -28,24 +34,24 @@
         </mj-column>
       </mj-section>
 
-      <mj-section padding="0">
+      <mj-section padding="0" css-class="set-font">
         <mj-column>
-          <mj-text align="left">on debian-2gb-nbdg1-1</mj-text>
+          <mj-text align="left" font-family="IBM Plex Sans, sans-serif">on debian-2gb-nbdg1-1</mj-text>
         </mj-column>
       </mj-section>
 
-      <mj-section>
+      <mj-section css-class="set-font">
         <mj-column>
           <mj-text align="left" font-size="26px" font-weight="700" padding-top="15px">
-            <mr-raw>
-              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; 100%; padding:4px 24px; border-radius: 36px">98%
+            <mj-raw>
+              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
               </span>
-            </mr-raw>
+            </mj-raw>
           </mj-text>
         </mj-column>
       </mj-section>
 
-      <mj-section padding-top="0" padding-bottom="0">
+      <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
         <mj-column>
           <mj-text align="left">
             Details: the percentage of time the disk was busy, during the last 10 minutes
@@ -53,22 +59,32 @@
         </mj-column>
       </mj-section>
 
-      <mj-section padding-top="0" padding-bottom="0">
-        <mj-column width="100%">
-          <mj-button align="left" background-color="#FF4136" color="#ffffff" height="44px" width="100%">
-            Go to Chart
+      <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
+        <mj-column width="50%">
+          <mj-button align="left" background-color="#FFFFFF" border="1px solid #FF4136" color="#FF4136" height="44px" width="100%">
+            RUN CORRELATIONS
           </mj-button>
         </mj-column>
-        <mj-columne>
+        <mj-column width="50%">
+          <mj-button align="left" background-color="#FF4136" color="#ffffff" height="44px" width="100%">
+            GO TO CHART
+          </mj-button>
+        </mj-column>
+      </mj-section>
 
-        </mj-columne>
+      <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
+        <mj-column width="100%">
+          <mj-button align="center" background-color="#FF4136" color="#ffffff" height="44px" width="100%" href="https://app.netdata.cloud">
+            GO TO CHART
+          </mj-button>
+        </mj-column>
       </mj-section>
 
     </mj-wrapper>
 
     <mj-spacer height="32px" />
 
-    <mj-section background-color="#FFEBEF">
+    <mj-section background-color="#FFEBEF" css-class="set-font">
       <mj-column>
         <mj-text align="left" font-size="18px">
           Chart:
@@ -106,7 +122,7 @@
       </mj-column>
     </mj-section>
 
-    <mj-section padding-left="0">
+    <mj-section padding-left="0" css-class="set-font">
       <mj-column padding="0" width="100px">
         <mj-image align="left" width="60px" src="https://app.netdata.cloud/static/email/img/community_icon.png" />
       </mj-column>
@@ -118,7 +134,7 @@
     </mj-section>
 
 
-    <mj-section padding-left="0">
+    <mj-section padding-left="0" css-class="set-font">
       <mj-column padding="0" width="100px">
         <mj-image align="left" src="https://app.netdata.cloud/static/email/img/configure_icon.png" width="60px" />
       </mj-column>
@@ -134,7 +150,7 @@
 
 
     <mj-wrapper background-color="#F7F8F8" full-width padding="0" css-class="history-wrapper" padding-bottom="24px">
-      <mj-section>
+      <mj-section css-class="set-font">
         <mj-column>
           <mj-text align="left" font-size="16px">
             The node has
@@ -146,27 +162,31 @@
         </mj-column>
       </mj-section>
 
-      <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8">
+      <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8" css-class="set-font">
         <mj-column>
           <mj-text align="left" font-size="14px" font-weight="600">10_m_response_time</mj-text>
           <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
         </mj-column>
-        <mj-column>
-          <mj-text><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px;">
-            Warning for 10m
-          </mj-raw></mj-text>
+        <mj-column padding-top="13px">
+          <mj-text align="right">
+            <span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
+              Warning for 10mm
+            </span>
+          </mj-text>
         </mj-column>
       </mj-section>
 
-      <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8">
+      <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8" css-class="set-font">
         <mj-column>
           <mj-text align="left" font-size="14px" font-weight="600">10_m_response_time</mj-text>
           <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
         </mj-column>
-        <mj-column>
-          <mj-text><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
-            Warning for 10m
-          </mj-raw></mj-text>
+        <mj-column padding-top="13px">
+          <mj-text align="right">
+            <span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
+              Warning for 10m
+            </span>
+          </mj-text>
         </mj-column>
       </mj-section>
 

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -4,11 +4,8 @@
     <mj-font name="IBM Plex Sans"
              href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap"
     />
-    <mj-style>
-      .value { background-color: pink; display: inline }
-      .history-wrapper { max-width: 100% !important; }
-    </mj-style>
     <mj-style inline="inline">
+      .history-wrapper { max-width: 100% !important; }
       .set-font { font-family: "IBM Plex Sans", sans-serif }
       .link { color: #00AB44; text-decoration: none;  }
     </mj-style>

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -164,7 +164,7 @@
         </mj-column>
         <mj-column padding-top="13px">
           <mj-text align="right">
-            <span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
+            <span style="background-color:#FFF8E1; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
               Warning for 10mm
             </span>
           </mj-text>
@@ -178,8 +178,8 @@
         </mj-column>
         <mj-column padding-top="13px">
           <mj-text align="right">
-            <span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
-              Warning for 10m
+            <span style="background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 2px 12px;">
+              Critical for 10m
             </span>
           </mj-text>
         </mj-column>

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -1,0 +1,179 @@
+<mjml>
+
+  <mj-head>
+    <mj-style>
+      .value { background-color: pink; display: inline }
+      .link { color: #00AB44; text-decoration: none;  }
+      .history-wrapper { max-width: 100% !important; }
+    </mj-style>
+
+    <mj-attributes>
+      <mj-text align="center" color="#555" />
+    </mj-attributes>
+    <mj-breakpoint width="200px" />
+
+  </mj-head>
+
+  <mj-body padding="0">
+
+    <mj-include path="./header.mjml" />
+
+    <mj-wrapper	border="1px solid #FF4136">
+      <mj-section padding-bottom="0">
+        <mj-column width="70%">
+          <mj-text align="left" font-size="20px" font-weight="700" padding-top="15px">10min_disk_utilization</mj-text>
+        </mj-column>
+        <mj-column width="30%">
+          <mj-image align="center" width="100px" src="https://app.netdata.cloud/static/email/img/label_critical.png" />
+        </mj-column>
+      </mj-section>
+
+      <mj-section padding="0">
+        <mj-column>
+          <mj-text align="left">on debian-2gb-nbdg1-1</mj-text>
+        </mj-column>
+      </mj-section>
+
+      <mj-section>
+        <mj-column>
+          <mj-text align="left" font-size="26px" font-weight="700" padding-top="15px">
+            <mr-raw>
+              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; 100%; padding:4px 24px; border-radius: 36px">98%
+              </span>
+            </mr-raw>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <mj-section padding-top="0" padding-bottom="0">
+        <mj-column>
+          <mj-text align="left">
+            Details: the percentage of time the disk was busy, during the last 10 minutes
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <mj-section padding-top="0">
+        <mj-column>
+          <mj-button align="left" background-color="#FF4136" color="#ffffff" height="44px" width="100%">
+            Go to Chart
+          </mj-button>
+        </mj-column>
+        <mj-column>
+
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+
+    <mj-spacer height="32px" />
+
+    <mj-section background-color="#FFEBEF">
+      <mj-column>
+        <mj-text align="left" font-size="18px">
+          Chart:
+          <mj-raw style="font-weight:700">disk.util</mj-raw>
+        </mj-text>
+        <mj-text align="left" font-size="18px" padding-top="0">
+          Family:
+          <mj-raw style="font-weight:700">8tb</mj-raw>
+        </mj-text>
+        <mj-text align="left" font-size="14px">Escalated from Warning, raised for 5 minutes</mj-text>
+        <mj-divider border-width="1px" border-style="solid" border-color="lightgrey" />
+
+        <mj-text align="left" font-size="18px">
+          On
+          <mj-raw style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</mj-raw>
+        </mj-text>
+        <mj-text align="left" font-size="18px" padding-top="0">
+          By:
+          <mj-raw style="font-weight:500">{host name}</mj-raw>
+        </mj-text>
+        <mj-text align="left" font-size="14px">Global time:
+          <my-raw style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</my-raw>
+        </mj-text>
+        <mj-divider border-width="1px" border-style="solid" border-color="lightgrey" />
+
+        <mj-text align="left" font-size="18px">
+          Classification:
+          <mj-raw style="font-weight:500">OS disk</mj-raw>
+        </mj-text>
+        <mj-text align="left" font-size="18px" padding-top="0">
+          Role:
+          <mj-raw style="font-weight:500">sysadmin</mj-raw>
+        </mj-text>
+
+      </mj-column>
+    </mj-section>
+
+    <mj-section>
+      <mj-column width="20%" align="left">
+        <mj-image align="center" src="https://app.netdata.cloud/static/email/img/community_icon.png" />
+      </mj-column>
+      <mj-column align="left" width="60%">
+        <mj-text align="left" font-weight="700" font-size="16px">Want to know more about this alert?</mj-text>
+        <mj-text align="left" font-size="14px" line-height="1.3">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></mj-text>
+
+      </mj-column>
+    </mj-section>
+
+
+    <mj-section>
+      <mj-column width="20%" align="left">
+        <mj-image align="left" src="https://app.netdata.cloud/static/email/img/configure_icon.png" widteeh="60px" />
+      </mj-column>
+      <mj-column align="left" width="60%">
+        <mj-text align="left" font-weight="700" font-size="16px">Need to configure this alert?</mj-text>
+        <mj-text align="left" font-size="14px" line-height="1.3"><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into {node} and running the following command:</mj-text>
+        <mj-text align="left" font-size="12px" line-height="1.3" padding-top="8px">
+          sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br />
+          The alarm to edit is at line {160}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+
+    <mj-wrapper background-color="#F7F8F8" full-width padding="0" css-class="history-wrapper">
+      <mj-section>
+        <mj-column>
+          <mj-text align="left" font-size="16px">
+            The node has
+            <mj-raw style="font-weight:600">3 warnings</mj-raw>
+            and
+            <mj-raw style="font-weight:600">0 critical</mj-raw>
+            alert(s)
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8">
+        <mj-column>
+          <mj-text align="left" font-size="14px" font-weight="600">10_m_response_time</mj-text>
+          <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
+        </mj-column>
+        <mj-column>
+          <mj-text><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+            Warning for 10m
+          </mj-raw></mj-text>
+        </mj-column>
+      </mj-section>
+
+      <mj-section background-color="#FFFFFF" border-top="8px solid #F7F8F8">
+        <mj-column>
+          <mj-text align="left" font-size="14px" font-weight="600">10_m_response_time</mj-text>
+          <mj-text align="left" font-size="12px">Sat Nov 10 2021, 16:04:08 UTC</mj-text>
+        </mj-column>
+        <mj-column>
+          <mj-text><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+            Warning for 10m
+          </mj-raw></mj-text>
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+
+    <mj-include path="./footer.mjml" />
+
+  </mj-body>
+
+</mjml>

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -9,13 +9,11 @@
       .set-font { font-family: "IBM Plex Sans", sans-serif; }
       .link { color: #00AB44; text-decoration: none;  }
       .svgbg {
-      background-image: url("https://app.netdata.cloud/static/img/mail/isotype.png");
+      background-image: url('https://staging.netdata.cloud/static/email/img/isotype_600.png');
       background-repeat: no-repeat;
-      background-position: 0 -40px;
-      background-size: 334px 265px;
+      background-position: top center;
+      background-size: 600px 192px;
       }
-      .no-collapse { border-collapse: initial; }
-
     </mj-style>
 
     <mj-attributes>
@@ -28,7 +26,7 @@
 
     <mj-include path="./header.mjml" />
 
-    <mj-wrapper	border="1px solid #FF4136" border-radius="4px" css-class="no-collapse">
+    <mj-wrapper	border="1px solid #FF4136" border-radius="4px">
       <mj-section padding-bottom="0" padding-top="0" css-class="set-font">
         <mj-column width="70%">
           <mj-text align="left" font-size="20px" font-weight="700" padding-top="15px">10min_disk_utilization</mj-text>

--- a/src/email-templates/alert-notification/notification-template.mjml
+++ b/src/email-templates/alert-notification/notification-template.mjml
@@ -1,39 +1,46 @@
 <mjml>
 
   <mj-head>
-    <mj-font name="IBM Plex Sans"
-             href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap"
+    <mj-font name="Open Sans"
+             href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&display=swap"
     />
     <mj-style inline="inline">
       .history-wrapper { max-width: 100% !important; }
-      .set-font { font-family: "IBM Plex Sans", sans-serif }
+      .set-font { font-family: "IBM Plex Sans", sans-serif; }
       .link { color: #00AB44; text-decoration: none;  }
+      .svgbg {
+      background-image: url("https://app.netdata.cloud/static/img/mail/isotype.png");
+      background-repeat: no-repeat;
+      background-position: 0 -40px;
+      background-size: 334px 265px;
+      }
+      .no-collapse { border-collapse: initial; }
+
     </mj-style>
 
     <mj-attributes>
-      <mj-text align="center" color="#555" />
+      <mj-text align="left" color="#35414A" font-family="Open Sans, sans-serif"; />
     </mj-attributes>
     <mj-breakpoint width="100px" />
-
   </mj-head>
 
-  <mj-body padding="0">
+  <mj-body padding="0" css-class="svgbg" style="color: #35414A;">
 
     <mj-include path="./header.mjml" />
 
-    <mj-wrapper	border="1px solid #FF4136">
+    <mj-wrapper	border="1px solid #FF4136" border-radius="4px" css-class="no-collapse">
       <mj-section padding-bottom="0" padding-top="0" css-class="set-font">
         <mj-column width="70%">
           <mj-text align="left" font-size="20px" font-weight="700" padding-top="15px">10min_disk_utilization</mj-text>
         </mj-column>
         <mj-column width="30%">
-          <mj-image align="center" width="100px" src="https://app.netdata.cloud/static/email/img/label_critical.png" />
+          <mj-image align="right" padding-right="25px" width="100px" src="https://app.netdata.cloud/static/email/img/label_critical.png" />
         </mj-column>
       </mj-section>
 
       <mj-section padding="0" css-class="set-font">
         <mj-column>
-          <mj-text padding-top="0" align="left" font-family="IBM Plex Sans, sans-serif">on debian-2gb-nbdg1-1</mj-text>
+          <mj-text font-size="16px" padding-top="0" align="left" font-family="IBM Plex Sans, sans-serif">on debian-2gb-nbdg1-1</mj-text>
         </mj-column>
       </mj-section>
 
@@ -56,20 +63,12 @@
 
       <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
         <mj-column width="50%">
-          <mj-button align="left" background-color="#FFFFFF" border="1px solid #FF4136" color="#FF4136" height="44px" width="100%" font-weight="600">
+          <mj-button align="left" padding-right="8px" background-color="#FFFFFF" border="1px solid #FF4136" color="#FF4136" height="44px" width="100%" font-weight="600">
             RUN CORRELATIONS
           </mj-button>
         </mj-column>
         <mj-column width="50%">
-          <mj-button align="left" background-color="#FF4136" color="#ffffff" height="44px" width="100%" font-weight="600">
-            GO TO CHART
-          </mj-button>
-        </mj-column>
-      </mj-section>
-
-      <mj-section padding-top="0" padding-bottom="0" css-class="set-font">
-        <mj-column width="100%">
-          <mj-button align="center" background-color="#FF4136" color="#ffffff" height="44px" width="100%" href="https://app.netdata.cloud" font-weight="600">
+          <mj-button align="left" padding-left="8px" background-color="#FF4136" color="#ffffff" height="44px" width="100%" font-weight="600">
             GO TO CHART
           </mj-button>
         </mj-column>
@@ -79,64 +78,64 @@
 
     <mj-spacer height="32px" />
 
-    <mj-section background-color="#FFEBEF" css-class="set-font">
+    <mj-section background-color="#FFEBEF" border-radius="4px" css-class="set-font">
       <mj-column>
         <mj-text align="left" font-size="18px" padding-bottom="6px">
           Chart:
-          <span style="font-weight:700">disk.util</span>
+          <span style="font-weight:700; font-size:20px">disk.util</span>
         </mj-text>
         <mj-text align="left" font-size="18px" padding-top="0">
           Family:
-          <span style="font-weight:700">8tb</span>
+          <span style="font-weight:700; font-size:20px">8tb</span>
         </mj-text>
         <mj-text align="left" font-size="14px" padding-top="4px">Escalated from Warning, raised for 5 minutes</mj-text>
         <mj-divider border-width="1px" border-style="solid" border-color="lightgrey" />
 
         <mj-text align="left" font-size="16px" padding-bottom="6px">
           On
-          <span style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</span>
+          <span style="font-weight:600">Sat Nov 10 2021, 04:28:23 EET</span>
         </mj-text>
         <mj-text align="left" font-size="16px" padding-top="0">
           By:
-          <span style="font-weight:500">{host name}</span>
+          <span style="font-weight:600">{host name}</span>
         </mj-text>
         <mj-text align="left" font-size="14px" padding-top="4px">Global time:
-          <span style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</span>
+          <span style="font-weight:600">Sat Nov 10 2021, 16:28:23 UTC</span>
         </mj-text>
         <mj-divider border-width="1px" border-style="solid" border-color="lightgrey" />
 
         <mj-text align="left" font-size="16px" padding-bottom="6px">
           Classification:
-          <span style="font-weight:500">OS disk</span>
+          <span style="font-weight:600">OS disk</span>
         </mj-text>
         <mj-text align="left" font-size="16px" padding-top="0">
           Role:
-          <span style="font-weight:500">sysadmin</span>
+          <span style="font-weight:600">sysadmin</span>
         </mj-text>
 
       </mj-column>
     </mj-section>
 
-    <mj-section padding-left="0" css-class="set-font">
-      <mj-column padding="0" width="100px">
-        <mj-image align="left" width="60px" src="https://app.netdata.cloud/static/email/img/community_icon.png" />
+    <mj-section padding-left="25px" css-class="set-font" text-align="left">
+      <mj-column padding="0" width="66px">
+        <mj-image align="left" padding-left="0" padding-right="0" width="48px" src="https://app.netdata.cloud/static/email/img/community_icon.png" />
       </mj-column>
-      <mj-column align="left" width="80%">
-        <mj-text align="left" font-weight="700" font-size="16px">Want to know more about this alert?</mj-text>
-        <mj-text align="left" font-size="14px" line-height="1.3">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></mj-text>
+      <mj-column align="left" width="400px" padding-left="0">
+        <mj-text align="left" font-weight="700" font-size="16px" padding-left="0">Want to know more about this alert?</mj-text>
+        <mj-text align="left" font-size="14px" line-height="1.3" padding-left="0">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></mj-text>
 
       </mj-column>
     </mj-section>
 
 
-    <mj-section padding-left="0" css-class="set-font">
-      <mj-column padding="0" width="100px">
-        <mj-image align="left" src="https://app.netdata.cloud/static/email/img/configure_icon.png" width="60px" />
+    <mj-section padding-left="25px" css-class="set-font" text-align="left">
+      <mj-column padding="0" width="66px">
+        <mj-image align="left" padding-left="0" padding-right="0" src="https://app.netdata.cloud/static/email/img/configure_icon.png" width="48px" />
       </mj-column>
-      <mj-column align="left" width="80%">
-        <mj-text align="left" font-weight="700" font-size="16px">Need to configure this alert?</mj-text>
-        <mj-text align="left" font-size="14px" line-height="1.3"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</mj-text>
-        <mj-text align="left" font-size="12px" line-height="1.3" padding-top="8px">
+      <mj-column align="left" width="400px" padding-left="0">
+        <mj-text align="left" font-weight="700" font-size="16px" padding-left="0">Need to configure this alert?</mj-text>
+        <mj-text align="left" font-size="14px" line-height="1.3" padding-left="0"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</mj-text>
+        <mj-text align="left" font-size="12px" line-height="1.3" padding-left="0" padding-top="8px">
           sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br />
           The alarm to edit is at line {160}
         </mj-text>
@@ -145,7 +144,7 @@
 
 
     <mj-wrapper background-color="#F7F8F8" full-width padding="0" css-class="history-wrapper" padding-bottom="24px">
-      <mj-section css-class="set-font">
+      <mj-section css-class="set-font" padding-bottom="12px">
         <mj-column>
           <mj-text align="left" font-size="16px">
             The node has
@@ -164,7 +163,7 @@
         </mj-column>
         <mj-column padding-top="13px">
           <mj-text align="right">
-            <span style="background-color:#FFF8E1; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
+            <span style="background-color:#FFF8E1; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px; white-space: nowrap">
               Warning for 10mm
             </span>
           </mj-text>
@@ -178,7 +177,7 @@
         </mj-column>
         <mj-column padding-top="13px">
           <mj-text align="right">
-            <span style="background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 2px 12px;">
+            <span style="background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 2px 12px; white-space: nowrap">
               Critical for 10m
             </span>
           </mj-text>

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -41,13 +41,13 @@
 
 
   <style type="text/css">
-      @media only screen and (min-width:200px) {
+      @media only screen and (min-width:100px) {
           .mj-column-per-100 { width:100% !important; max-width: 100%; }
           .mj-column-per-70 { width:70% !important; max-width: 70%; }
           .mj-column-per-30 { width:30% !important; max-width: 30%; }
+          .mj-column-px-100 { width:100px !important; max-width: 100px; }
+          .mj-column-per-80 { width:80% !important; max-width: 80%; }
           .mj-column-per-50 { width:50% !important; max-width: 50%; }
-          .mj-column-per-20 { width:20% !important; max-width: 20%; }
-          .mj-column-per-60 { width:60% !important; max-width: 60%; }
       }
   </style>
 
@@ -56,7 +56,7 @@
 
 
 
-      @media only screen and (max-width:200px) {
+      @media only screen and (max-width:100px) {
           table.mj-full-width-mobile { width: 100% !important; }
           td.mj-full-width-mobile { width: auto !important; }
       }
@@ -161,7 +161,7 @@
               <tbody>
               <tr>
                 <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;text-align:center;"
+                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
                 >
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:418.6px;" ><![endif]-->
 
@@ -404,12 +404,12 @@
               <tbody>
               <tr>
                 <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-top:0;text-align:center;"
+                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
                 >
-                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:299px;" ><![endif]-->
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
                   <div
-                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
                   >
 
                     <table
@@ -440,22 +440,6 @@
 
                         </td>
                       </tr>
-
-                      </tbody>
-                    </table>
-
-                  </div>
-
-                  <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:299px;" ><![endif]-->
-
-                  <div
-                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
-
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
-                      <tbody>
 
                       </tbody>
                     </table>
@@ -674,52 +658,64 @@
       <tbody>
       <tr>
         <td
-          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+          style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;"
         >
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td align="left" class="" style="vertical-align:top;width:120px;" ><![endif]-->
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
           <div
-            class="mj-column-per-20 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
           >
 
             <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+              border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"
             >
               <tbody>
-
               <tr>
-                <td
-                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td  style="vertical-align:top;padding:0;">
 
                   <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%"
                   >
                     <tbody>
-                    <tr>
-                      <td  style="width:70px;">
 
-                        <img
-                          height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="70"
-                        />
+                    <tr>
+                      <td
+                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                      >
+
+                        <table
+                          border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                        >
+                          <tbody>
+                          <tr>
+                            <td  style="width:50px;">
+
+                              <img
+                                height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
+                              />
+
+                            </td>
+                          </tr>
+                          </tbody>
+                        </table>
 
                       </td>
                     </tr>
+
                     </tbody>
                   </table>
 
                 </td>
               </tr>
-
               </tbody>
             </table>
 
           </div>
 
-          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:360px;" ><![endif]-->
+          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
 
           <div
-            class="mj-column-per-60 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
           >
 
             <table
@@ -776,52 +772,64 @@
       <tbody>
       <tr>
         <td
-          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+          style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;"
         >
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td align="left" class="" style="vertical-align:top;width:120px;" ><![endif]-->
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
           <div
-            class="mj-column-per-20 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
           >
 
             <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+              border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"
             >
               <tbody>
-
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td  style="vertical-align:top;padding:0;">
 
                   <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%"
                   >
                     <tbody>
-                    <tr>
-                      <td  style="width:70px;">
 
-                        <img
-                          height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="70"
-                        />
+                    <tr>
+                      <td
+                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                      >
+
+                        <table
+                          border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                        >
+                          <tbody>
+                          <tr>
+                            <td  style="width:50px;">
+
+                              <img
+                                height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
+                              />
+
+                            </td>
+                          </tr>
+                          </tbody>
+                        </table>
 
                       </td>
                     </tr>
+
                     </tbody>
                   </table>
 
                 </td>
               </tr>
-
               </tbody>
             </table>
 
           </div>
 
-          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:360px;" ><![endif]-->
+          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
 
           <div
-            class="mj-column-per-60 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
           >
 
             <table
@@ -891,7 +899,7 @@
       <tbody>
       <tr>
         <td
-          style="direction:ltr;font-size:0px;padding:0;text-align:center;"
+          style="direction:ltr;font-size:0px;padding:0;padding-bottom:24px;text-align:center;"
         >
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
@@ -1018,7 +1026,7 @@
 
                           <div
                             style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;"
-                          ><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+                          ><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px;">
                             Warning for 10m
                           </mj-raw></div>
 
@@ -1110,7 +1118,7 @@
 
                           <div
                             style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;"
-                          ><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+                          ><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
                             Warning for 10m
                           </mj-raw></div>
 

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -1,0 +1,1200 @@
+
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <title>
+
+  </title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+  </style>
+  <!--[if mso]>
+  <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+  </xml>
+  <![endif]-->
+  <!--[if lte mso 11]>
+  <style type="text/css">
+    .mj-outlook-group-fix { width:100% !important; }
+  </style>
+  <![endif]-->
+
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+      @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+  </style>
+  <!--<![endif]-->
+
+
+
+  <style type="text/css">
+      @media only screen and (min-width:200px) {
+          .mj-column-per-100 { width:100% !important; max-width: 100%; }
+          .mj-column-per-70 { width:70% !important; max-width: 70%; }
+          .mj-column-per-30 { width:30% !important; max-width: 30%; }
+          .mj-column-per-50 { width:50% !important; max-width: 50%; }
+          .mj-column-per-20 { width:20% !important; max-width: 20%; }
+          .mj-column-per-60 { width:60% !important; max-width: 60%; }
+      }
+  </style>
+
+
+  <style type="text/css">
+
+
+
+      @media only screen and (max-width:200px) {
+          table.mj-full-width-mobile { width: 100% !important; }
+          td.mj-full-width-mobile { width: auto !important; }
+      }
+
+  </style>
+  <style type="text/css">.value { background-color: pink; display: inline }
+  .link { color: #00AB44; text-decoration: none;  }
+  .history-wrapper { max-width: 100% !important; }</style>
+
+</head>
+<body style="word-spacing:normal;">
+
+
+<div
+  style=""
+>
+
+
+  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div  style="margin:0px auto;max-width:600px;">
+
+    <table
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+    >
+      <tbody>
+      <tr>
+        <td
+          style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:50px;text-align:center;"
+        >
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+          >
+
+            <table
+              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+            >
+              <tbody>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;"
+                >
+
+                  <table
+                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                  >
+                    <tbody>
+                    <tr>
+                      <td  style="width:575px;">
+
+                        <img
+                          height="auto" src="https://app.netdata.cloud/static/email/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="575"
+                        />
+
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div  style="margin:0px auto;max-width:600px;">
+
+    <table
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+    >
+      <tbody>
+      <tr>
+        <td
+          style="border:1px solid #FF4136;direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+        >
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="margin:0px auto;max-width:598px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:418.6px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                          >10min_disk_utilization</div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:179.4px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <table
+                            border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                          >
+                            <tbody>
+                            <tr>
+                              <td  style="width:100px;">
+
+                                <img
+                                  height="auto" src="https://app.netdata.cloud/static/email/img/label_critical.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100"
+                                />
+
+                              </td>
+                            </tr>
+                            </tbody>
+                          </table>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="margin:0px auto;max-width:598px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="direction:ltr;font-size:0px;padding:0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
+                          >on debian-2gb-nbdg1-1</div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="margin:0px auto;max-width:598px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                          ><mr-raw>
+              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; 100%; padding:4px 24px; border-radius: 36px">98%
+              </span>
+                          </mr-raw></div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="margin:0px auto;max-width:598px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
+                          >Details: the percentage of time the disk was busy, during the last 10 minutes</div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="margin:0px auto;max-width:598px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="direction:ltr;font-size:0px;padding:20px 0;padding-top:0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:299px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <table
+                            border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;"
+                          >
+                            <tr>
+                              <td
+                                align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle"
+                              >
+                                <p
+                                  style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;"
+                                >
+                                  Go to Chart
+                                </p>
+                              </td>
+                            </tr>
+                          </table>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:299px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><![endif]-->
+
+
+  <div
+    style="height:32px;line-height:32px;"
+  >&#8202;</div>
+
+
+  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div  style="background:#FFEBEF;background-color:#FFEBEF;margin:0px auto;max-width:600px;">
+
+    <table
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFEBEF;background-color:#FFEBEF;width:100%;"
+    >
+      <tbody>
+      <tr>
+        <td
+          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+        >
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+          >
+
+            <table
+              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+            >
+              <tbody>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                  >Chart:
+                    <mj-raw style="font-weight:700">disk.util</mj-raw></div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                  >Family:
+                    <mj-raw style="font-weight:700">8tb</mj-raw></div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
+                  >Escalated from Warning, raised for 5 minutes</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <p
+                    style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;"
+                  >
+                  </p>
+
+                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+            </td></tr></table><![endif]-->
+
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                  >On
+                    <mj-raw style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</mj-raw></div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                  >By:
+                    <mj-raw style="font-weight:500">{host name}</mj-raw></div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
+                  >Global time:
+                    <my-raw style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</my-raw></div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <p
+                    style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;"
+                  >
+                  </p>
+
+                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+            </td></tr></table><![endif]-->
+
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                  >Classification:
+                    <mj-raw style="font-weight:500">OS disk</mj-raw></div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                  >Role:
+                    <mj-raw style="font-weight:500">sysadmin</mj-raw></div>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div  style="margin:0px auto;max-width:600px;">
+
+    <table
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+    >
+      <tbody>
+      <tr>
+        <td
+          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+        >
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td align="left" class="" style="vertical-align:top;width:120px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-20 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+          >
+
+            <table
+              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+            >
+              <tbody>
+
+              <tr>
+                <td
+                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <table
+                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                  >
+                    <tbody>
+                    <tr>
+                      <td  style="width:70px;">
+
+                        <img
+                          height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="70"
+                        />
+
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:360px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-60 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+          >
+
+            <table
+              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+            >
+              <tbody>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                  >Want to know more about this alert?</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
+                  >Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></div>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div  style="margin:0px auto;max-width:600px;">
+
+    <table
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+    >
+      <tbody>
+      <tr>
+        <td
+          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+        >
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td align="left" class="" style="vertical-align:top;width:120px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-20 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+          >
+
+            <table
+              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+            >
+              <tbody>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <table
+                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+                  >
+                    <tbody>
+                    <tr>
+                      <td  style="width:70px;">
+
+                        <img
+                          height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="70"
+                        />
+
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:360px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-60 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+          >
+
+            <table
+              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+            >
+              <tbody>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                  >Need to configure this alert?</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
+                  ><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into {node} and running the following command:</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;"
+                  >sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br />
+                    The alarm to edit is at line {160}</div>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="history-wrapper-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div  class="history-wrapper" style="background:#F7F8F8;background-color:#F7F8F8;margin:0px auto;max-width:600px;">
+
+    <table
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F7F8F8;background-color:#F7F8F8;width:100%;"
+    >
+      <tbody>
+      <tr>
+        <td
+          style="direction:ltr;font-size:0px;padding:0;text-align:center;"
+        >
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="margin:0px auto;max-width:600px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;"
+                          >The node has
+                            <mj-raw style="font-weight:600">3 warnings</mj-raw>
+                            and
+                            <mj-raw style="font-weight:600">0 critical</mj-raw>
+                            alert(s)</div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;"
+                          >10_m_response_time</div>
+
+                        </td>
+                      </tr>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;"
+                          >Sat Nov 10 2021, 16:04:08 UTC</div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;"
+                          ><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+                            Warning for 10m
+                          </mj-raw></div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div  style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+
+            <table
+              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;"
+            >
+              <tbody>
+              <tr>
+                <td
+                  style="border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+                >
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;"
+                          >10_m_response_time</div>
+
+                        </td>
+                      </tr>
+
+                      <tr>
+                        <td
+                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;"
+                          >Sat Nov 10 2021, 16:04:08 UTC</div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
+
+                  <div
+                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                  >
+
+                    <table
+                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+                    >
+                      <tbody>
+
+                      <tr>
+                        <td
+                          align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                        >
+
+                          <div
+                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;"
+                          ><mj-raw style="background-color:#FFEDB3; border-radius:36px; padding: 2px 12px;">
+                            Warning for 10m
+                          </mj-raw></div>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div  style="margin:0px auto;max-width:600px;">
+
+    <table
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+    >
+      <tbody>
+      <tr>
+        <td
+          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+        >
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+          >
+
+            <table
+              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+            >
+              <tbody>
+
+              <tr>
+                <td
+                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+                  <div
+                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
+                  >© Netdata 2021 - The real-time performance and health monitoring</div>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><![endif]-->
+
+
+</div>
+
+</body>
+</html>
+

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -65,7 +65,6 @@
 
   </style>
   <style type="text/css">.value { background-color: pink; display: inline }
-  .link { color: #00AB44; text-decoration: none;  }
   .history-wrapper { max-width: 100% !important; }</style>
 
 </head>
@@ -217,7 +216,7 @@
                       <tbody>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
                           <div style="font-family:IBM Plex Sans, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">on debian-2gb-nbdg1-1</div>
 
@@ -255,12 +254,10 @@
                       <tbody>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"><mj-raw>
-              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
-              </span>
-                          </mj-raw></div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"><span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
+            </span></div>
 
                         </td>
                       </tr>
@@ -296,9 +293,9 @@
                       <tbody>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:21px;text-align:left;color:#555555;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
 
                         </td>
                       </tr>
@@ -339,7 +336,7 @@
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:1px solid #FF4136;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                <p style="display:inline-block;background:#FFFFFF;color:#FF4136;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                <p style="display:inline-block;background:#FFFFFF;color:#FF4136;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
                                   RUN CORRELATIONS
                                 </p>
                               </td>
@@ -367,7 +364,7 @@
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
-                                <p style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                <p style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
                                   GO TO CHART
                                 </p>
                               </td>
@@ -413,7 +410,7 @@
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
-                                <a href="https://app.netdata.cloud" style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
+                                <a href="https://app.netdata.cloud" style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
                                   GO TO CHART
                                 </a>
                               </td>
@@ -469,10 +466,10 @@
               <tbody>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Chart:
-                    <mj-raw style="font-weight:700">disk.util</mj-raw></div>
+                    <span style="font-weight:700">disk.util</span></div>
 
                 </td>
               </tr>
@@ -481,13 +478,13 @@
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Family:
-                    <mj-raw style="font-weight:700">8tb</mj-raw></div>
+                    <span style="font-weight:700">8tb</span></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Escalated from Warning, raised for 5 minutes</div>
 
@@ -508,10 +505,10 @@
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">On
-                    <mj-raw style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</mj-raw></div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">On
+                    <span style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</span></div>
 
                 </td>
               </tr>
@@ -519,17 +516,17 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">By:
-                    <mj-raw style="font-weight:500">{host name}</mj-raw></div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">By:
+                    <span style="font-weight:500">{host name}</span></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
                   <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Global time:
-                    <my-raw style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</my-raw></div>
+                    <span style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</span></div>
 
                 </td>
               </tr>
@@ -548,10 +545,10 @@
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Classification:
-                    <mj-raw style="font-weight:500">OS disk</mj-raw></div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Classification:
+                    <span style="font-weight:500">OS disk</span></div>
 
                 </td>
               </tr>
@@ -559,8 +556,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Role:
-                    <mj-raw style="font-weight:500">sysadmin</mj-raw></div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Role:
+                    <span style="font-weight:500">sysadmin</span></div>
 
                 </td>
               </tr>
@@ -646,7 +643,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link" style="color: #00AB44; text-decoration: none;">community forums</a></div>
 
                 </td>
               </tr>
@@ -732,7 +729,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into {node} and running the following command:</div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</div>
 
                 </td>
               </tr>
@@ -789,9 +786,9 @@
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                           <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">The node has
-                            <mj-raw style="font-weight:600">3 warnings</mj-raw>
+                            <span style="font-weight:600">3 warnings</span>
                             and
-                            <mj-raw style="font-weight:600">0 critical</mj-raw>
+                            <span style="font-weight:600">0 critical</span>
                             alert(s)</div>
 
                         </td>
@@ -836,7 +833,7 @@
                       </tr>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;">
 
                           <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
@@ -914,7 +911,7 @@
                       </tr>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;">
 
                           <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
@@ -1021,4 +1018,3 @@
 
 </body>
 </html>
-

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -149,7 +149,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;">10min_disk_utilization</div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;">10min_disk_utilization</div>
 
                         </td>
                       </tr>
@@ -255,7 +255,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"><span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"><span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
             </span></div>
 
                         </td>
@@ -294,7 +294,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:21px;text-align:left;color:#555555;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:21px;text-align:left;color:#555555;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
 
                         </td>
                       </tr>
@@ -335,7 +335,7 @@
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:1px solid #FF4136;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                <p style="display:inline-block;background:#FFFFFF;color:#FF4136;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                <p style="display:inline-block;background:#FFFFFF;color:#FF4136;font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
                                   RUN CORRELATIONS
                                 </p>
                               </td>
@@ -363,7 +363,7 @@
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
-                                <p style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                <p style="display:inline-block;background:#FF4136;color:#ffffff;font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
                                   GO TO CHART
                                 </p>
                               </td>
@@ -409,7 +409,7 @@
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
-                                <a href="https://app.netdata.cloud" style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
+                                <a href="https://app.netdata.cloud" style="display:inline-block;background:#FF4136;color:#ffffff;font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
                                   GO TO CHART
                                 </a>
                               </td>
@@ -467,7 +467,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Chart:
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Chart:
                     <span style="font-weight:700">disk.util</span></div>
 
                 </td>
@@ -476,7 +476,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Family:
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Family:
                     <span style="font-weight:700">8tb</span></div>
 
                 </td>
@@ -485,7 +485,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Escalated from Warning, raised for 5 minutes</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Escalated from Warning, raised for 5 minutes</div>
 
                 </td>
               </tr>
@@ -506,7 +506,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">On
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">On
                     <span style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</span></div>
 
                 </td>
@@ -515,7 +515,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">By:
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">By:
                     <span style="font-weight:500">{host name}</span></div>
 
                 </td>
@@ -524,7 +524,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Global time:
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Global time:
                     <span style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</span></div>
 
                 </td>
@@ -546,7 +546,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Classification:
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Classification:
                     <span style="font-weight:500">OS disk</span></div>
 
                 </td>
@@ -555,7 +555,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Role:
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Role:
                     <span style="font-weight:500">sysadmin</span></div>
 
                 </td>
@@ -634,7 +634,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Want to know more about this alert?</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Want to know more about this alert?</div>
 
                 </td>
               </tr>
@@ -642,7 +642,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link" style="color: #00AB44; text-decoration: none;">community forums</a></div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link" style="color: #00AB44; text-decoration: none;">community forums</a></div>
 
                 </td>
               </tr>
@@ -720,7 +720,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Need to configure this alert?</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Need to configure this alert?</div>
 
                 </td>
               </tr>
@@ -728,7 +728,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</div>
 
                 </td>
               </tr>
@@ -736,7 +736,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;">sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;">sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br>
                     The alarm to edit is at line {160}</div>
 
                 </td>
@@ -784,7 +784,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">The node has
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">The node has
                             <span style="font-weight:600">3 warnings</span>
                             and
                             <span style="font-weight:600">0 critical</span>
@@ -826,7 +826,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
 
                         </td>
                       </tr>
@@ -834,7 +834,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
                         </td>
                       </tr>
@@ -859,7 +859,7 @@
                             <tr>
                               <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                                <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
+                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
               Warning for 10mm
            </span></div>
 
@@ -904,7 +904,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
 
                         </td>
                       </tr>
@@ -912,7 +912,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;">
 
-                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
                         </td>
                       </tr>
@@ -937,7 +937,7 @@
                             <tr>
                               <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                                <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
+                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
               Warning for 10m
             </span></div>
 
@@ -991,7 +991,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">© Netdata 2021 - The real-time performance and health monitoring</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">© Netdata 2021 - The real-time performance and health monitoring</div>
 
                 </td>
               </tr>

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -859,7 +859,7 @@
                             <tr>
                               <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
+                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFF8E1; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
               Warning for 10mm
            </span></div>
 
@@ -937,8 +937,8 @@
                             <tr>
                               <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
-              Warning for 10m
+                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 2px 12px;">
+              Critical for 10m
             </span></div>
 
                               </td>
@@ -1017,4 +1017,3 @@
 
 </body>
 </html>
-

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -64,8 +64,7 @@
       }
 
   </style>
-  <style type="text/css">.value { background-color: pink; display: inline }
-  .history-wrapper { max-width: 100% !important; }</style>
+
 
 </head>
 <body style="word-spacing:normal;">
@@ -760,7 +759,7 @@
   <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="history-wrapper-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div class="history-wrapper" style="background:#F7F8F8;background-color:#F7F8F8;margin:0px auto;max-width:600px;">
+  <div class="history-wrapper" style="background: #F7F8F8; background-color: #F7F8F8; margin: 0px auto; max-width: 100%;">
 
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F7F8F8;background-color:#F7F8F8;width:100%;">
       <tbody>
@@ -1018,3 +1017,4 @@
 
 </body>
 </html>
+

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -33,8 +33,10 @@
 
   <!--[if !mso]><!-->
   <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" type="text/css">
   <style type="text/css">
       @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+      @import url(https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap);
   </style>
   <!--<![endif]-->
 
@@ -45,9 +47,9 @@
           .mj-column-per-100 { width:100% !important; max-width: 100%; }
           .mj-column-per-70 { width:70% !important; max-width: 70%; }
           .mj-column-per-30 { width:30% !important; max-width: 30%; }
+          .mj-column-per-50 { width:50% !important; max-width: 50%; }
           .mj-column-px-100 { width:100px !important; max-width: 100px; }
           .mj-column-per-80 { width:80% !important; max-width: 80%; }
-          .mj-column-per-50 { width:50% !important; max-width: 50%; }
       }
   </style>
 
@@ -70,50 +72,34 @@
 <body style="word-spacing:normal;">
 
 
-<div
-  style=""
->
+<div style>
 
 
   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div style="margin:0px auto;max-width:600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:50px;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:50px;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
 
-                  <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                  >
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                     <tbody>
                     <tr>
-                      <td  style="width:575px;">
+                      <td style="width:575px;">
 
-                        <img
-                          height="auto" src="https://app.netdata.cloud/static/email/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="575"
-                        />
+                        <img height="auto" src="https://app.netdata.cloud/static/email/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="575">
 
                       </td>
                     </tr>
@@ -140,48 +126,32 @@
   <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div style="margin:0px auto;max-width:600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="border:1px solid #FF4136;direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-        >
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <td style="border:1px solid #FF4136;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:418.6px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                          >10min_disk_utilization</div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;">10min_disk_utilization</div>
 
                         </td>
                       </tr>
@@ -193,30 +163,20 @@
 
                   <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:179.4px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <table
-                            border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                          >
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                             <tbody>
                             <tr>
-                              <td  style="width:100px;">
+                              <td style="width:100px;">
 
-                                <img
-                                  height="auto" src="https://app.netdata.cloud/static/email/img/label_critical.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100"
-                                />
+                                <img height="auto" src="https://app.netdata.cloud/static/email/img/label_critical.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100">
 
                               </td>
                             </tr>
@@ -240,38 +200,26 @@
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
-                          >on debian-2gb-nbdg1-1</div>
+                          <div style="font-family:IBM Plex Sans, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">on debian-2gb-nbdg1-1</div>
 
                         </td>
                       </tr>
@@ -290,41 +238,29 @@
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                          ><mr-raw>
-              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; 100%; padding:4px 24px; border-radius: 36px">98%
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"><mj-raw>
+              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
               </span>
-                          </mr-raw></div>
+                          </mj-raw></div>
 
                         </td>
                       </tr>
@@ -343,38 +279,26 @@
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
-                          >Details: the percentage of time the disk was busy, during the last 10 minutes</div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
 
                         </td>
                       </tr>
@@ -393,47 +317,105 @@
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
-                >
-                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:299px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <table
-                            border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;"
-                          >
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
-                              <td
-                                align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle"
-                              >
-                                <p
-                                  style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;"
-                                >
-                                  Go to Chart
+                              <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:1px solid #FF4136;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                <p style="display:inline-block;background:#FFFFFF;color:#FF4136;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                  RUN CORRELATIONS
                                 </p>
+                              </td>
+                            </tr>
+                          </table>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:299px;" ><![endif]-->
+
+                  <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                      <tbody>
+
+                      <tr>
+                        <td align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
+                            <tr>
+                              <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
+                                <p style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                  GO TO CHART
+                                </p>
+                              </td>
+                            </tr>
+                          </table>
+
+                        </td>
+                      </tr>
+
+                      </tbody>
+                    </table>
+
+                  </div>
+
+                  <!--[if mso | IE]></td></tr></table><![endif]-->
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
+
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+              <tbody>
+              <tr>
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
+                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
+
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                      <tbody>
+
+                      <tr>
+                        <td align="center" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
+                            <tr>
+                              <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
+                                <a href="https://app.netdata.cloud" style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
+                                  GO TO CHART
+                                </a>
                               </td>
                             </tr>
                           </table>
@@ -467,81 +449,55 @@
   <!--[if mso | IE]></td></tr></table><![endif]-->
 
 
-  <div
-    style="height:32px;line-height:32px;"
-  >&#8202;</div>
+  <div style="height:32px;line-height:32px;">&#8202;</div>
 
 
-  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="background:#FFEBEF;background-color:#FFEBEF;margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; background: #FFEBEF; background-color: #FFEBEF; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFEBEF;background-color:#FFEBEF;width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFEBEF;background-color:#FFEBEF;width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Chart:
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Chart:
                     <mj-raw style="font-weight:700">disk.util</mj-raw></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Family:
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Family:
                     <mj-raw style="font-weight:700">8tb</mj-raw></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
-                  >Escalated from Warning, raised for 5 minutes</div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Escalated from Warning, raised for 5 minutes</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <p
-                    style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;"
-                  >
+                  <p style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;">
                   </p>
 
                   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
@@ -552,52 +508,36 @@
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >On
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">On
                     <mj-raw style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</mj-raw></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >By:
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">By:
                     <mj-raw style="font-weight:500">{host name}</mj-raw></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
-                  >Global time:
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Global time:
                     <my-raw style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</my-raw></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <p
-                    style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;"
-                  >
+                  <p style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;">
                   </p>
 
                   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
@@ -608,26 +548,18 @@
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Classification:
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Classification:
                     <mj-raw style="font-weight:500">OS disk</mj-raw></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Role:
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Role:
                     <mj-raw style="font-weight:500">sysadmin</mj-raw></div>
 
                 </td>
@@ -647,52 +579,36 @@
   </div>
 
 
-  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
-          <div
-            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
               <tr>
-                <td  style="vertical-align:top;padding:0;">
+                <td style="vertical-align:top;padding:0;">
 
-                  <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%"
-                  >
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
                     <tbody>
 
                     <tr>
-                      <td
-                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                      >
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                        <table
-                          border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                        >
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                           <tr>
-                            <td  style="width:50px;">
+                            <td style="width:50px;">
 
-                              <img
-                                height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
-                              />
+                              <img height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50">
 
                             </td>
                           </tr>
@@ -714,35 +630,23 @@
 
           <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                  >Want to know more about this alert?</div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Want to know more about this alert?</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
-                  >Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></div>
 
                 </td>
               </tr>
@@ -761,52 +665,36 @@
   </div>
 
 
-  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
-          <div
-            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
               <tr>
-                <td  style="vertical-align:top;padding:0;">
+                <td style="vertical-align:top;padding:0;">
 
-                  <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%"
-                  >
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
                     <tbody>
 
                     <tr>
-                      <td
-                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                      >
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                        <table
-                          border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                        >
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                           <tr>
-                            <td  style="width:50px;">
+                            <td style="width:50px;">
 
-                              <img
-                                height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
-                              />
+                              <img height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50">
 
                             </td>
                           </tr>
@@ -828,47 +716,31 @@
 
           <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                  >Need to configure this alert?</div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Need to configure this alert?</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
-                  ><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into {node} and running the following command:</div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into {node} and running the following command:</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;"
-                  >sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br />
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;">sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br>
                     The alarm to edit is at line {160}</div>
 
                 </td>
@@ -891,48 +763,32 @@
   <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="history-wrapper-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  class="history-wrapper" style="background:#F7F8F8;background-color:#F7F8F8;margin:0px auto;max-width:600px;">
+  <div class="history-wrapper" style="background:#F7F8F8;background-color:#F7F8F8;margin:0px auto;max-width:600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F7F8F8;background-color:#F7F8F8;width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F7F8F8;background-color:#F7F8F8;width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:0;padding-bottom:24px;text-align:center;"
-        >
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <td style="direction:ltr;font-size:0px;padding:0;padding-bottom:24px;text-align:center;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:600px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;"
-                          >The node has
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">The node has
                             <mj-raw style="font-weight:600">3 warnings</mj-raw>
                             and
                             <mj-raw style="font-weight:600">0 critical</mj-raw>
@@ -955,50 +811,34 @@
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; background: #FFFFFF; background-color: #FFFFFF; margin: 0px auto; max-width: 600px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-                >
+                <td style="border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;"
-                          >10_m_response_time</div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
 
                         </td>
                       </tr>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;"
-                          >Sat Nov 10 2021, 16:04:08 UTC</div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
                         </td>
                       </tr>
@@ -1010,29 +850,31 @@
 
                   <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                       <tbody>
-
                       <tr>
-                        <td
-                          align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td style="vertical-align:top;padding-top:13px;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;"
-                          ><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px;">
-                            Warning for 10m
-                          </mj-raw></div>
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                            <tbody>
+
+                            <tr>
+                              <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+
+                                <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
+              Warning for 10mm
+           </span></div>
+
+                              </td>
+                            </tr>
+
+                            </tbody>
+                          </table>
 
                         </td>
                       </tr>
-
                       </tbody>
                     </table>
 
@@ -1047,50 +889,34 @@
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; background: #FFFFFF; background-color: #FFFFFF; margin: 0px auto; max-width: 600px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-                >
+                <td style="border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;"
-                          >10_m_response_time</div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
 
                         </td>
                       </tr>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;"
-                          >Sat Nov 10 2021, 16:04:08 UTC</div>
+                          <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
                         </td>
                       </tr>
@@ -1102,29 +928,31 @@
 
                   <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
                       <tbody>
-
                       <tr>
-                        <td
-                          align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td style="vertical-align:top;padding-top:13px;">
 
-                          <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;"
-                          ><mj-raw style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
-                            Warning for 10m
-                          </mj-raw></div>
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                            <tbody>
+
+                            <tr>
+                              <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+
+                                <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;">
+              Warning for 10m
+            </span></div>
+
+                              </td>
+                            </tr>
+
+                            </tbody>
+                          </table>
 
                         </td>
                       </tr>
-
                       </tbody>
                     </table>
 
@@ -1148,38 +976,26 @@
   </div>
 
 
-  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
-                  >© Netdata 2021 - The real-time performance and health monitoring</div>
+                  <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">© Netdata 2021 - The real-time performance and health monitoring</div>
 
                 </td>
               </tr>

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -71,7 +71,7 @@
 <body style="word-spacing:normal;">
 
 
-<div class="svgbg" style="background-image: url('https://app.netdata.cloud/static/img/mail/isotype.png'); background-repeat: no-repeat; background-position: 0 -40px; background-size: 334px 265px;">
+<div class="svgbg" style="background-image: url('https://staging.netdata.cloud/static/email/img/isotype_600.png'); background-repeat: no-repeat; background-position: top center; background-size: 600px 192px;">
 
 
   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->

--- a/src/email-templates/alert-notification/output.html
+++ b/src/email-templates/alert-notification/output.html
@@ -32,11 +32,11 @@
   <![endif]-->
 
   <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" type="text/css">
   <style type="text/css">
+      @import url(https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&display=swap);
       @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
-      @import url(https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap);
   </style>
   <!--<![endif]-->
 
@@ -44,12 +44,13 @@
 
   <style type="text/css">
       @media only screen and (min-width:100px) {
-          .mj-column-per-100 { width:100% !important; max-width: 100%; }
+          .mj-column-px-130 { width:130px !important; max-width: 130px; }
+          .mj-column-per-50 { width:50% !important; max-width: 50%; }
           .mj-column-per-70 { width:70% !important; max-width: 70%; }
           .mj-column-per-30 { width:30% !important; max-width: 30%; }
-          .mj-column-per-50 { width:50% !important; max-width: 50%; }
-          .mj-column-px-100 { width:100px !important; max-width: 100px; }
-          .mj-column-per-80 { width:80% !important; max-width: 80%; }
+          .mj-column-per-100 { width:100% !important; max-width: 100%; }
+          .mj-column-px-66 { width:66px !important; max-width: 66px; }
+          .mj-column-px-400 { width:400px !important; max-width: 400px; }
       }
   </style>
 
@@ -70,7 +71,7 @@
 <body style="word-spacing:normal;">
 
 
-<div style>
+<div class="svgbg" style="background-image: url('https://app.netdata.cloud/static/img/mail/isotype.png'); background-repeat: no-repeat; background-position: 0 -40px; background-size: 334px 265px;">
 
 
   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
@@ -81,23 +82,23 @@
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:50px;text-align:center;">
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:50px;padding-left:0;text-align:left;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:130px;" ><![endif]-->
 
-          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+          <div class="mj-column-px-130 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
             <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
+                <td align="center" style="font-size:0px;padding:10px 25px;padding-right:0;padding-left:0;word-break:break-word;">
 
                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                     <tbody>
                     <tr>
-                      <td style="width:575px;">
+                      <td style="width:130px;">
 
-                        <img height="auto" src="https://app.netdata.cloud/static/email/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="575">
+                        <img alt="Netdata Logo" height="auto" src="https://app.netdata.cloud/static/email/img/full_logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="130">
 
                       </td>
                     </tr>
@@ -107,6 +108,36 @@
                 </td>
               </tr>
 
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:300px;" ><![endif]-->
+
+          <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+              <tbody>
+              <tr>
+                <td style="vertical-align:top;padding-top:4px;">
+
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                    <tbody>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-left:10px;word-break:break-word;">
+
+                        <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">Notification</div>
+
+                      </td>
+                    </tr>
+
+                    </tbody>
+                  </table>
+
+                </td>
+              </tr>
               </tbody>
             </table>
 
@@ -124,9 +155,9 @@
   <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div style="margin:0px auto;max-width:600px;">
+  <div style="margin:0px auto;border-radius:4px;max-width:600px;">
 
-    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px;">
       <tbody>
       <tr>
         <td style="border:1px solid #FF4136;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
@@ -149,7 +180,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;">10min_disk_utilization</div>
+                          <div style="font-family:Open Sans, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#35414A;">10min_disk_utilization</div>
 
                         </td>
                       </tr>
@@ -167,7 +198,7 @@
                       <tbody>
 
                       <tr>
-                        <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="right" style="font-size:0px;padding:10px 25px;padding-right:25px;word-break:break-word;">
 
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                             <tbody>
@@ -217,7 +248,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div style="font-family:IBM Plex Sans, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">on debian-2gb-nbdg1-1</div>
+                          <div style="font-family:IBM Plex Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">on debian-2gb-nbdg1-1</div>
 
                         </td>
                       </tr>
@@ -255,7 +286,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"><span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
+                          <div style="font-family:Open Sans, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#35414A;"><span style="color: #FF4136; font-size:26px; background: #FFEBEF; padding:4px 24px; border-radius: 36px">98%
             </span></div>
 
                         </td>
@@ -294,7 +325,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:21px;text-align:left;color:#555555;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
+                          <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:21px;text-align:left;color:#35414A;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
 
                         </td>
                       </tr>
@@ -330,12 +361,12 @@
                       <tbody>
 
                       <tr>
-                        <td align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;padding-right:8px;word-break:break-word;">
 
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:1px solid #FF4136;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                <p style="display:inline-block;background:#FFFFFF;color:#FF4136;font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                <p style="display:inline-block;background:#FFFFFF;color:#FF4136;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
                                   RUN CORRELATIONS
                                 </p>
                               </td>
@@ -358,60 +389,14 @@
                       <tbody>
 
                       <tr>
-                        <td align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;padding-left:8px;word-break:break-word;">
 
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
-                                <p style="display:inline-block;background:#FF4136;color:#ffffff;font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
+                                <p style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;">
                                   GO TO CHART
                                 </p>
-                              </td>
-                            </tr>
-                          </table>
-
-                        </td>
-                      </tr>
-
-                      </tbody>
-                    </table>
-
-                  </div>
-
-                  <!--[if mso | IE]></td></tr></table><![endif]-->
-                </td>
-              </tr>
-              </tbody>
-            </table>
-
-          </div>
-
-
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-
-
-          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
-
-            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-              <tbody>
-              <tr>
-                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
-                  <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
-
-                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-
-                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-                      <tbody>
-
-                      <tr>
-                        <td align="center" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-
-                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
-                            <tr>
-                              <td align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle">
-                                <a href="https://app.netdata.cloud" style="display:inline-block;background:#FF4136;color:#ffffff;font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
-                                  GO TO CHART
-                                </a>
                               </td>
                             </tr>
                           </table>
@@ -451,9 +436,9 @@
   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; background: #FFEBEF; background-color: #FFEBEF; margin: 0px auto; max-width: 600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; background: #FFEBEF; background-color: #FFEBEF; margin: 0px auto; border-radius: 4px; max-width: 600px;">
 
-    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFEBEF;background-color:#FFEBEF;width:100%;">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFEBEF;background-color:#FFEBEF;width:100%;border-radius:4px;">
       <tbody>
       <tr>
         <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
@@ -467,8 +452,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Chart:
-                    <span style="font-weight:700">disk.util</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:18px;line-height:1;text-align:left;color:#35414A;">Chart:
+                    <span style="font-weight:700; font-size:20px">disk.util</span></div>
 
                 </td>
               </tr>
@@ -476,8 +461,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Family:
-                    <span style="font-weight:700">8tb</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:18px;line-height:1;text-align:left;color:#35414A;">Family:
+                    <span style="font-weight:700; font-size:20px">8tb</span></div>
 
                 </td>
               </tr>
@@ -485,7 +470,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Escalated from Warning, raised for 5 minutes</div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:14px;line-height:1;text-align:left;color:#35414A;">Escalated from Warning, raised for 5 minutes</div>
 
                 </td>
               </tr>
@@ -506,8 +491,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">On
-                    <span style="font-weight:500">Sat Nov 10 2021, 04:28:23 EET</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">On
+                    <span style="font-weight:600">Sat Nov 10 2021, 04:28:23 EET</span></div>
 
                 </td>
               </tr>
@@ -515,8 +500,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">By:
-                    <span style="font-weight:500">{host name}</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">By:
+                    <span style="font-weight:600">{host name}</span></div>
 
                 </td>
               </tr>
@@ -524,8 +509,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Global time:
-                    <span style="font-weight:500">Sat Nov 10 2021, 16:28:23 UTC</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:14px;line-height:1;text-align:left;color:#35414A;">Global time:
+                    <span style="font-weight:600">Sat Nov 10 2021, 16:28:23 UTC</span></div>
 
                 </td>
               </tr>
@@ -546,8 +531,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Classification:
-                    <span style="font-weight:500">OS disk</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">Classification:
+                    <span style="font-weight:600">OS disk</span></div>
 
                 </td>
               </tr>
@@ -555,8 +540,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Role:
-                    <span style="font-weight:500">sysadmin</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">Role:
+                    <span style="font-weight:600">sysadmin</span></div>
 
                 </td>
               </tr>
@@ -583,10 +568,10 @@
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:25px;text-align:left;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:66px;" ><![endif]-->
 
-          <div class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+          <div class="mj-column-px-66 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
             <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
@@ -597,14 +582,14 @@
                     <tbody>
 
                     <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-right:0;padding-left:0;word-break:break-word;">
 
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                           <tr>
-                            <td style="width:50px;">
+                            <td style="width:48px;">
 
-                              <img height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50">
+                              <img height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="48">
 
                             </td>
                           </tr>
@@ -624,29 +609,39 @@
 
           </div>
 
-          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
+          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:400px;" ><![endif]-->
 
-          <div class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+          <div class="mj-column-px-400 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
-
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td style="vertical-align:top;padding-left:0;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Want to know more about this alert?</div>
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                    <tbody>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
+
+                        <div style="font-family:Open Sans, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#35414A;">Want to know more about this alert?</div>
+
+                      </td>
+                    </tr>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
+
+                        <div style="font-family:Open Sans, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#35414A;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link" style="color: #00AB44; text-decoration: none;">community forums</a></div>
+
+                      </td>
+                    </tr>
+
+                    </tbody>
+                  </table>
 
                 </td>
               </tr>
-
-              <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link" style="color: #00AB44; text-decoration: none;">community forums</a></div>
-
-                </td>
-              </tr>
-
               </tbody>
             </table>
 
@@ -669,10 +664,10 @@
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:25px;text-align:left;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:66px;" ><![endif]-->
 
-          <div class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+          <div class="mj-column-px-66 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
             <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
@@ -683,14 +678,14 @@
                     <tbody>
 
                     <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-right:0;padding-left:0;word-break:break-word;">
 
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                           <tr>
-                            <td style="width:50px;">
+                            <td style="width:48px;">
 
-                              <img height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50">
+                              <img height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="48">
 
                             </td>
                           </tr>
@@ -710,38 +705,48 @@
 
           </div>
 
-          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
+          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:400px;" ><![endif]-->
 
-          <div class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+          <div class="mj-column-px-400 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
-
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td style="vertical-align:top;padding-left:0;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Need to configure this alert?</div>
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                    <tbody>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
+
+                        <div style="font-family:Open Sans, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#35414A;">Need to configure this alert?</div>
+
+                      </td>
+                    </tr>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
+
+                        <div style="font-family:Open Sans, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#35414A;"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</div>
+
+                      </td>
+                    </tr>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;padding-left:0;word-break:break-word;">
+
+                        <div style="font-family:Open Sans, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#35414A;">sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br>
+                          The alarm to edit is at line {160}</div>
+
+                      </td>
+                    </tr>
+
+                    </tbody>
+                  </table>
 
                 </td>
               </tr>
-
-              <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into {node} and running the following command:</div>
-
-                </td>
-              </tr>
-
-              <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;">
-
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;">sudo {/etc/netdata}/edit-config health.d/{disks.conf} <br>
-                    The alarm to edit is at line {160}</div>
-
-                </td>
-              </tr>
-
               </tbody>
             </table>
 
@@ -773,7 +778,7 @@
             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:12px;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
                   <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
@@ -784,7 +789,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">The node has
+                          <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">The node has
                             <span style="font-weight:600">3 warnings</span>
                             and
                             <span style="font-weight:600">0 critical</span>
@@ -826,7 +831,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
+                          <div style="font-family:Open Sans, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#35414A;">10_m_response_time</div>
 
                         </td>
                       </tr>
@@ -834,7 +839,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
+                          <div style="font-family:Open Sans, sans-serif;font-size:12px;line-height:1;text-align:left;color:#35414A;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
                         </td>
                       </tr>
@@ -859,7 +864,7 @@
                             <tr>
                               <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFF8E1; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px">
+                                <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:right;color:#35414A;"><span style="background-color:#FFF8E1; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px; white-space: nowrap">
               Warning for 10mm
            </span></div>
 
@@ -904,7 +909,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;">10_m_response_time</div>
+                          <div style="font-family:Open Sans, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#35414A;">10_m_response_time</div>
 
                         </td>
                       </tr>
@@ -912,7 +917,7 @@
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;">
 
-                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;">Sat Nov 10 2021, 16:04:08 UTC</div>
+                          <div style="font-family:Open Sans, sans-serif;font-size:12px;line-height:1;text-align:left;color:#35414A;">Sat Nov 10 2021, 16:04:08 UTC</div>
 
                         </td>
                       </tr>
@@ -937,7 +942,7 @@
                             <tr>
                               <td align="right" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                                <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;"><span style="background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 2px 12px;">
+                                <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:right;color:#35414A;"><span style="background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 2px 12px; white-space: nowrap">
               Critical for 10m
             </span></div>
 
@@ -985,17 +990,27 @@
 
           <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
-
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td style="vertical-align:top;padding-top:44px;padding-bottom:12px;">
 
-                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">© Netdata 2021 - The real-time performance and health monitoring</div>
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                    <tbody>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
+
+                        <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:left;color:#35414A;">© Netdata 2021 - The real-time performance and health monitoring</div>
+
+                      </td>
+                    </tr>
+
+                    </tbody>
+                  </table>
 
                 </td>
               </tr>
-
               </tbody>
             </table>
 


### PR DESCRIPTION
We have a common alarm template in [Agent](https://github.com/netdata/netdata/blob/alerts-changes-notify-attributes/health/notifications/alarm-notify.sh.in#L2863-L3673) and in the Cloud. To have the common source of truth, let's keep it here.

It is in 2 formats:
1) .mjml files (see https://mjml.io/)
2) .html file (output.html) copy/pasted from mjml app. In the future, if we want, we can use mjml npm package to automatically generate output.html.