### PR TITLE
badge wrap + clear-alarm fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.15.4",
+  "version": "2.15.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.15.4",
+  "version": "2.15.5",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/chart/components/lib-charts/alarmBadge.js
+++ b/src/domains/chart/components/lib-charts/alarmBadge.js
@@ -41,6 +41,7 @@ const Badge = styled.div`
   font-size: 12px;
   font-weight: 700;
   direction: ltr;
+  white-space: nowrap;
 `
 
 export default forwardRef((

--- a/src/domains/chart/components/lib-charts/dygraph-chart.tsx
+++ b/src/domains/chart/components/lib-charts/dygraph-chart.tsx
@@ -535,8 +535,10 @@ export const DygraphChart = ({
             // use RAF, because dygraph doesn't provide any callback called after drawing the chart
             requestAnimationFrame(() => {
               canvas.fillStyle = fillColor
+              const globalAlphaCache = canvas.globalAlpha
               canvas.globalAlpha = 0.7
               canvas.fillRect(alarmPosition - horizontalPadding, area.y, 2 * horizontalPadding, area.h)
+              canvas.globalAlpha = globalAlphaCache
             })
 
             propsRef.current.updateAlarmBadge(
@@ -881,13 +883,13 @@ export const DygraphChart = ({
   }, [attributes, unitsCurrent])
 
 
-  // immediately update when changing global chart underlay
+  // immediately update when changing global chart underlay or currently showed alarm
   useUpdateEffect(() => {
     if (dygraphInstance.current) {
       dygraphInstance.current.updateOptions({})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [globalChartUnderlay])
+  }, [alarm, globalChartUnderlay])
 
   const spacePanelTransitionEndIsActive = useSelector(selectSpacePanelTransitionEndIsActive)
   useUpdateEffect(() => {


### PR DESCRIPTION
- prevent badge wrapping when being on left side of the screen
- update highlight immediately after clearing current alarm

This is already released on *npm* as v2.15.5