### PR TITLE
Automatically trigger an agent PR on dashboard release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,12 @@ jobs:
           asset_name: dashboard.tar.gz
           asset_content_type: application/gzip
           upload_url: ${{ github.event.release.upload_url }}
+      - name: 'Trigger agent code update'
+        if: github.event.release.prerelease == false
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
+          repo: netdata/netdata
+          workflow: Dashboard Version PR
+          ref: refs/heads/master
+          inputs: {"dashboard_version": "${{ github.event.release.tag_name }}"}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
           repo: netdata/netdata
           workflow: Dashboard Version PR
           ref: refs/heads/master
-          inputs: {"dashboard_version": "${{ github.event.release.tag_name }}"}
+          inputs: '{"dashboard_version": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
This will automatically run a workflow in the agent repo to generate a PR to update the agent to the newest version of the dashboard whenever a release that is not a prerelease is created.

This will be marked ready for review once netdata/netdata#11076 is merged, as it has a hard dependency on that PR.

Closes: #269 

I’ve tagged @netdata/cloud-fe for review to get a confirmation that the described behavior is what we want. The other review requests are to help ensure correctness of the change itself.