### PR TITLE
fix after/before persistence in url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,9 +120,9 @@ const App: React.FC = () => {
         // styling will have smaller priority than bootstrap css
         <NotificationsContainer />
       )}
-      {chartsMetadata && cloudBaseURL && hasFetchedInfo && (
+      {chartsMetadata && cloudBaseURL && hasFetchedInfo && haveDOMReadyForParsing && (
         <Layout printMode={isPrintMode}>
-          {hasFetchDependencies && haveDOMReadyForParsing && (
+          {hasFetchDependencies && (
             <>
               <Portals key={refreshHelper} />
               <SidebarSocialMediaPortal>


### PR DESCRIPTION
Fixes a situation where after/before/highlight_after/highlight_before were reset after reload. That was happening because date-picker was resetting it before main.js' function `finalizePage()` could read the timestamps from url.