### PR TITLE
Clean netdata naming

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang="en">
 <head>
-    <title>NetData Dashboard</title>
+    <title>Netdata Dashboard</title>
     <meta name="application-name" content="netdata">
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -25,7 +25,7 @@
 
 <div class="container-fluid">
 
-<h1>NetData Custom Dashboard <div data-netdata="system.cpu" data-chart-library="sparkline" data-height="30" data-after="-600" data-sparkline-linecolor="#888"></div></h1>
+<h1>Netdata Custom Dashboard <div data-netdata="system.cpu" data-chart-library="sparkline" data-height="30" data-after="-600" data-sparkline-linecolor="#888"></div></h1>
 
 This is a template for building custom dashboards. To build a dashboard you just do this:
 
@@ -518,8 +518,8 @@ Sparklines using dygraphs
 
 <hr>
 <h1>Google Charts</h1>
-NetData was originaly developed with Google Charts.
-NetData is a complete Google Visualization API provider.
+Netdata was originaly developed with Google Charts.
+Netdata is a complete Google Visualization API provider.
 <br/>
 <div style="width: 33%; display: inline-block;">
     <div data-netdata="system.processes"

--- a/public/demo.html
+++ b/public/demo.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang="en">
 <head>
-    <title>NetData Dashboard</title>
+    <title>Netdata Dashboard</title>
     <meta name="application-name" content="netdata">
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/public/demo2.html
+++ b/public/demo2.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang="en">
 <head>
-    <title>NetData Dashboard</title>
+    <title>Netdata Dashboard</title>
     <meta name="application-name" content="netdata">
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/public/demosites.html
+++ b/public/demosites.html
@@ -4,7 +4,7 @@
 <head>
     <meta http-equiv="Refresh" content="0; url=https://www.netdata.cloud">
     <meta charset=utf-8>
-    <title>NetData: Get control of your Linux Servers. Simple. Effective. Awesome.</title>
+    <title>Netdata: Get control of your Linux Servers. Simple. Effective. Awesome.</title>
     <meta name=author content="Costa Tsaousis">
     <meta name=description content="Unparalleled insights, in real-time, of everything happening on your Linux systems and applications, with stunning, interactive web dashboards and powerful performance and health alarms.">
 

--- a/public/demosites2.html
+++ b/public/demosites2.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang="en">
 <head>
-    <title>NetData - Real-time performance monitoring, done right!</title>
+    <title>Netdata - Real-time performance monitoring, done right!</title>
     <meta name="application-name" content="netdata">
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/public/index-node-view.html
+++ b/public/index-node-view.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang="en">
 <head>
-  <title>NetData TV Dashboard</title>
+  <title>Netdata TV Dashboard</title>
   <meta name="application-name" content="netdata">
 
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/public/infographic.html
+++ b/public/infographic.html
@@ -3,7 +3,7 @@
 <html lang=en-us>
 <head>
     <meta charset=utf-8>
-    <title>NetData: Get control of your Linux Servers. Simple. Effective. Awesome.</title>
+    <title>Netdata: Get control of your Linux Servers. Simple. Effective. Awesome.</title>
     <meta name=author content="Costa Tsaousis">
     <meta name=description content="Unparalleled insights, in real-time, of everything happening on your Linux systems and applications, with stunning, interactive web dashboards and powerful performance and health alarms.">
 

--- a/public/tv-react.html
+++ b/public/tv-react.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang="en">
 <head>
-    <title>NetData TV Dashboard</title>
+    <title>Netdata TV Dashboard</title>
     <meta name="application-name" content="netdata">
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/public/tv.html
+++ b/public/tv.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang="en">
 <head>
-    <title>NetData TV Dashboard</title>
+    <title>Netdata TV Dashboard</title>
     <meta name="application-name" content="netdata">
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
This PR changes "NetData" to "Netdata" (according to [style-guide](https://github.com/netdata/netdata/blob/master/docs/contributing/style-guide.md#capitalization)).