### PR TITLE
fix rendering charts and menu: add anomaly_detection case

### DIFF
--- a/src/domains/dashboard/utils/render-charts-and-menu.ts
+++ b/src/domains/dashboard/utils/render-charts-and-menu.ts
@@ -120,7 +120,7 @@ function enrichChartData(chartName: string, chart: ChartMetadata, hasKubernetes:
       break
 
     case "anomaly":
-      if (parts.length > 2 && parts[1].startsWith('detection')) {
+      if (parts.length >= 2 && parts[1].startsWith('detection')) {
         chartEnriched.menu = `${tmp}_detection`
       }
       break

--- a/src/domains/dashboard/utils/render-charts-and-menu.ts
+++ b/src/domains/dashboard/utils/render-charts-and-menu.ts
@@ -120,10 +120,8 @@ function enrichChartData(chartName: string, chart: ChartMetadata, hasKubernetes:
       break
 
     case "anomaly":
-      if (parts.length > 2 && parts[1] === "detection") {
-        chartEnriched.menu_pattern = `${tmp}_${parts[1]}`
-      } else if (parts.length > 1) {
-        chartEnriched.menu_pattern = tmp
+      if (parts.length > 2 && parts[1].startsWith('detection')) {
+        chartEnriched.menu = `${tmp}_detection`
       }
       break
 

--- a/src/main.js
+++ b/src/main.js
@@ -1087,11 +1087,8 @@ function enrichChartData(chart) {
             break;
 
         case 'anomaly':
-            chart.menu = chart.type;
-            if (parts.length > 2 && parts[1] === 'detection') {
-                chart.menu_pattern = tmp + '_' + parts[1];
-            } else if (parts.length > 1) {
-                chart.menu_pattern = tmp;
+            if (parts.length >= 2 && parts[1].startsWith('detection')) {
+                chart.menu = tmp + '_detection';
             }
             break;
 


### PR DESCRIPTION
I tested it locally updating `/opt/netdata/usr/share/netdata/web/main.js` and checking `/old` endpoint.

```cmd
[pc ilyam]# cat /opt/netdata/usr/share/netdata/web/main.js | grep anomaly -A 5
        case 'anomaly':
            if (parts.length >= 2 && parts[1].startsWith('detection')) {
                chart.menu = tmp + '_detection';
            }
            break;
```

<details>
<summary>It works for me, see the screenshot</summary>

<img width="1417" alt="Screenshot 2021-09-29 at 14 39 22" src="https://user-images.githubusercontent.com/22274335/135261265-cee3f38a-f1d6-4167-a607-179727f33e53.png">

</details>