### PR TITLE
remove duplicate export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.20.16",
+  "version": "2.20.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.20.16",
+  "version": "2.20.17",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/charts/charts/context.js
+++ b/src/domains/charts/charts/context.js
@@ -20,7 +20,6 @@ export const ContainerContext = React.createContext({})
 export const GetChartContext = createContext({})
 export const MenuChartsAttributeById = createContext({})
 export const DashboardAttributesContext = createContext({})
-export const ListContext = createContext(null)
 
 export const ChartsProvider = ({
   container,


### PR DESCRIPTION
ListContext is exported twice (also in charts/list/index.js)
