### PR TITLE
Fix prometheus menus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.21.8",
+  "version": "2.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/dashboard",
-  "version": "2.21.8",
+  "version": "2.22.0",
   "homepage": ".",
   "main": "./lib/src/index-npm.js",
   "files": [

--- a/src/domains/charts/getChartMenu.js
+++ b/src/domains/charts/getChartMenu.js
@@ -1,12 +1,12 @@
 export default (
   { id, name, family, context, priority, chartLabels },
   submenuNames,
-  hasKubernetes
+  { hasKubernetes, composite } = {}
 ) => {
   const subMenuId = family || "all"
   const clusterId = hasKubernetes && chartLabels?.k8s_cluster_id?.[0]
 
-  const [type, typeB] = id.split(".")
+  const [type, typeB, typeC] = id.split(".")
   const parts = type.split("_")
   const [part1, part2] = parts
 
@@ -81,7 +81,13 @@ export default (
     }
 
     case "prometheus": {
-      if (parts.length !== 1) return emit({ menuPattern: "prometheus" })
+      if (parts.length !== 1) {
+        if (composite && typeC) return emit({ menuPattern: `${type} ${typeB.replace("_", " ")}` })
+
+        return emit({ menuPattern: "prometheus" })
+      }
+
+      if (composite && typeC) return emit({ menu: `${type} ${typeB.replace("_", " ")}` })
 
       const familyPart = family.split("_")[0]
       return emit({ menu: `prometheus ${familyPart}` })

--- a/src/domains/charts/getChartMenu.js
+++ b/src/domains/charts/getChartMenu.js
@@ -87,7 +87,7 @@ export default (
         return emit({ menuPattern: "prometheus" })
       }
 
-      if (composite && typeC) return emit({ menu: `${type} ${typeB.replace("_", " ")}` })
+      if (composite && typeC) return emit({ menu: `${type} ${typeB.replace("-", " ")}` })
 
       const familyPart = family.split("_")[0]
       return emit({ menu: `prometheus ${familyPart}` })

--- a/src/domains/charts/getChartMenu.js
+++ b/src/domains/charts/getChartMenu.js
@@ -82,7 +82,7 @@ export default (
 
     case "prometheus": {
       if (parts.length !== 1) {
-        if (composite && typeC) return emit({ menuPattern: `${type} ${typeB.replace("_", " ")}` })
+        if (composite && typeC) return emit({ menuPattern: `${type} ${typeB.replace("-", " ")}` })
 
         return emit({ menuPattern: "prometheus" })
       }

--- a/src/domains/charts/getMenu.js
+++ b/src/domains/charts/getMenu.js
@@ -5,7 +5,7 @@ import getChartMenu from "./getChartMenu"
 import getChartHeads from "./getChartHeads"
 import getMenuChartAttributes from "./getMenuChartAttributes"
 
-export const getMenuInfo = (chartIds, getChart, hasKubernetes) => {
+export const getMenuInfo = (chartIds, getChart, { hasKubernetes, composite } = {}) => {
   const submenuNames = {}
   const chartMenus = {}
   const menuChartsAttributeById = {}
@@ -16,7 +16,7 @@ export const getMenuInfo = (chartIds, getChart, hasKubernetes) => {
   chartIds.forEach(id => {
     const chart = getChart(id)
     menuChartsAttributeById[id] = getMenuChartAttributes(chart)
-    chartMenus[id] = getChartMenu(chart, submenuNames, hasKubernetes)
+    chartMenus[id] = getChartMenu(chart, submenuNames, { hasKubernetes, composite })
   })
 
   const sortedChartIds = [...chartIds].sort(
@@ -47,7 +47,7 @@ export const getMenuInfo = (chartIds, getChart, hasKubernetes) => {
   }
 }
 
-export default (chartIds, getChart, { hasKubernetes } = {}) => {
+export default (chartIds, getChart, { hasKubernetes, composite } = {}) => {
   const {
     chartMenus,
     menuChartsAttributeById,
@@ -55,7 +55,7 @@ export default (chartIds, getChart, { hasKubernetes } = {}) => {
     menuGroupChartIds,
     subMenus,
     submenuNames,
-  } = getMenuInfo(chartIds, getChart, hasKubernetes)
+  } = getMenuInfo(chartIds, getChart, { hasKubernetes, composite })
 
   const menuGroupById = Object.keys(menuGroups).reduce((acc, menuId) => {
     const chartIds = menuGroupChartIds[menuId]

--- a/src/domains/charts/provider.js
+++ b/src/domains/charts/provider.js
@@ -14,10 +14,11 @@ const Provider = ({
   getChart,
   dashboardAttributes,
   hasKubernetes,
+  composite,
   children,
 }) => {
   const { menuGroupIds, menuGroupById, subMenuById, menuChartsAttributeById } = useMemo(
-    () => getMenu(chartIds, getChart, { hasKubernetes }),
+    () => getMenu(chartIds, getChart, { hasKubernetes, composite }),
     [chartIds, getChart]
   )
 

--- a/src/domains/dashboard/components/virtualized/provider.js
+++ b/src/domains/dashboard/components/virtualized/provider.js
@@ -23,6 +23,7 @@ const Provider = ({
   chartIds,
   theme,
   hasKubernetes,
+  composite,
   children,
 }) => {
   const ref = useRef()
@@ -45,6 +46,7 @@ const Provider = ({
               onAttributesChange={onAttributesChange}
               dashboardAttributes={dashboardAttributes}
               hasKubernetes={hasKubernetes}
+              composite={composite}
             >
               {children}
             </DashboardMenuProvider>


### PR DESCRIPTION
Collector updates allow us to create a more clean menu for composite charts.

- Updates are backwards compatible with old collectors.
- Single node menu remains the same, since there is no grouping by context.