### PR TITLE
remove statsd menu hint, so that statsd will have a menu item per app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5565,7 +5565,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
     },
     "caniuse-api": {
       "version": "3.0.0",

--- a/src/domains/dashboard/utils/render-charts-and-menu.ts
+++ b/src/domains/dashboard/utils/render-charts-and-menu.ts
@@ -43,8 +43,6 @@ function enrichChartData(chartName: string, chart: ChartMetadata, hasKubernetes:
     case "net":
     case "disk":
     case "powersupply":
-    case "statsd":
-      chartEnriched.menu = tmp
       break
 
     case "cpufreq":

--- a/src/domains/dashboard/utils/render-charts-and-menu.ts
+++ b/src/domains/dashboard/utils/render-charts-and-menu.ts
@@ -43,6 +43,7 @@ function enrichChartData(chartName: string, chart: ChartMetadata, hasKubernetes:
     case "net":
     case "disk":
     case "powersupply":
+      chartEnriched.menu = tmp
       break
 
     case "cpufreq":

--- a/src/main.js
+++ b/src/main.js
@@ -1011,7 +1011,6 @@ function enrichChartData(chart) {
         case 'net':
         case 'disk':
         case 'powersupply':
-        case 'statsd':
             chart.menu = tmp;
             break;
 


### PR DESCRIPTION
We need to remove statsd from the menu of the agent (and the cloud) dashboard, so that each application pushing statsd metrics will get its own menu item named `statsd appname`.

This PR fixes it for the agent dashboard:

![image](https://user-images.githubusercontent.com/2662304/170124549-c0bb5808-85cb-448b-96f0-e4da66adeeda.png)

Related to https://github.com/netdata/netdata/pull/12980