### PR TITLE
fix: don't modify 'menu' for k8s charts on single node view

### DIFF
--- a/src/domains/charts/getChartMenu.js
+++ b/src/domains/charts/getChartMenu.js
@@ -64,17 +64,22 @@ export default (
     }
 
     case "k8s": {
-      if (part2 == "state") {
-        if (clusterName) return emit({ menu: `Kubernetes State ${clusterName}` })
-        else if (clusterId) return emit({ menu: `Kubernetes State ${clusterId}` })
+      if (composite) {
+        if (part2 == "state") {
+          if (clusterName) return emit({ menu: `Kubernetes State ${clusterName}` })
+          else if (clusterId) return emit({ menu: `Kubernetes State ${clusterId}` })
+        }
+
+        if (part2 == "container") {
+          if (clusterName) return emit({ menu: `Kubernetes Containers ${clusterName}` })
+          else if (clusterId) return emit({ menu: `Kubernetes Containers ${clusterId}` })
+        }
+
+        return emit({ menu: `Kubernetes ${part2}` })
       }
 
-      if (part2 == "container") {
-        if (clusterName) return emit({ menu: `Kubernetes Containers ${clusterName}` })
-        else if (clusterId) return emit({ menu: `Kubernetes Containers ${clusterId}` })
-      }
-
-      return emit({ menu: `Kubernetes ${part2}` })
+      const menuPattern = parts.length > 1 ? part1 : undefined
+      return emit({ menuPattern })
     }
 
     case "cgroup": {


### PR DESCRIPTION
Otherwise, [K8s state](https://github.com/netdata/go.d.plugin/tree/master/modules/k8s_state#kubernetes-cluster-state-monitoring-with-netdata) got squashed into one top-level section

<img width="226" alt="Screenshot 2022-06-16 at 19 10 27" src="https://user-images.githubusercontent.com/22274335/174116629-e0429c0f-a037-403e-8bc1-bd2599585d3c.png">

=>

<img width="1659" alt="Screenshot 2022-06-16 at 19 11 01" src="https://user-images.githubusercontent.com/22274335/174116727-7ba41f8a-e28e-48c5-a43a-b6fccd7aed65.png">


---

@jjtsou please test

