### PR TITLE
Different mem.available description for FreeBSD

### DIFF
--- a/src/dashboard_info.js
+++ b/src/dashboard_info.js
@@ -1648,7 +1648,12 @@ netdataDashboard.context = {
     },
 
     'mem.available': {
-        info: 'Available Memory is estimated by the kernel, as the amount of RAM that can be used by userspace processes, without causing swapping.'
+        info: function (os) {
+            if (os === "freebsd")
+                return 'The amount of memory that can be used by user-space processes without causing swapping. Calculated as the sum of free, cached, and inactive memory.';
+            else
+                return 'Available Memory is estimated by the kernel, as the amount of RAM that can be used by userspace processes, without causing swapping.';
+        }
     },
 
     'mem.writeback': {


### PR DESCRIPTION
Adds a check for FreeBSD and uses a different description for `mem.available` chart on FreeBSD.

This change is already available in https://github.com/netdata/netdata/blob/222a3f59e82434033297560511595d80ada0886f/web/gui/dashboard_info.js#L1733-L1740, advised by @ilyam8 it needs to be here as well (thanks!).

Not sure how to test (don't want to break dashboard), this is just copy paste from the above change.