### PR TITLE
Handle dnsmasq_dhcp case when rendering menu

### DIFF
--- a/src/domains/charts/getChartMenu.js
+++ b/src/domains/charts/getChartMenu.js
@@ -103,6 +103,17 @@ export default (
       return emit({ menuPattern })
     }
 
+    case "dnsmasq": {
+      if (parts.length == 2 && parts[1] === "dhcp") {
+        return emit({ menu: `${part1}_${part2}` })
+      }
+      if (parts.length >= 2 && parts[1] === "dhcp") {
+        return emit({ menuPattern: `${part1}_${part2}` })
+      }
+      const menuPattern = parts.length > 1 ? part1 : undefined
+      return emit({ menuPattern })
+    }
+
     case "prometheus": {
       if (parts.length !== 1) {
         if (composite && typeC) return emit({ menuPattern: `${type} ${typeB.replace("-", " ")}` })

--- a/src/domains/dashboard/utils/render-charts-and-menu.ts
+++ b/src/domains/dashboard/utils/render-charts-and-menu.ts
@@ -128,6 +128,16 @@ function enrichChartData(chartName: string, chart: ChartMetadata, hasKubernetes:
       }
       break
 
+    case "dnsmasq":
+      if (parts.length == 2 && parts[1] === "dhcp") {
+        chartEnriched.menu = `${tmp}_${parts[1]}`
+      } else if (parts.length > 2 && parts[1] === "dhcp") {
+        chartEnriched.menu_pattern = `${tmp}_${parts[1]}`
+      } else if (parts.length > 1) {
+        chartEnriched.menu_pattern = tmp
+      }
+      break
+
     case "anomaly":
       if (parts.length >= 2 && parts[1].startsWith('detection')) {
         chartEnriched.menu = `${tmp}_detection`

--- a/src/main.js
+++ b/src/main.js
@@ -1085,6 +1085,17 @@ function enrichChartData(chart) {
             }
             break;
 
+        case 'dnsmasq':
+            chart.menu = chart.type;
+            if (parts.length == 2 && parts[1] === 'dhcp') {
+                chart.menu = tmp + '_' + parts[1];
+            } else if (parts.length > 2 && parts[1] === 'dhcp') {
+                chart.menu_pattern = tmp + '_' + parts[1];
+            } else if (parts.length > 1) {
+                chart.menu_pattern = tmp;
+            }
+            break;
+
         case 'anomaly':
             if (parts.length >= 2 && parts[1].startsWith('detection')) {
                 chart.menu = tmp + '_detection';


### PR DESCRIPTION
There is an old problem (probably a feature at this point) with matching collector ([netdataDashboard.menu](https://github.com/netdata/dashboard/blob/master/src/dashboard_info.js#L13)) names with underscores in dashboard_info.js.

We have two collectors:
 - dnsmasq
 - dnsmasq_dhcp

See the example for web_log:

https://github.com/netdata/dashboard/blob/99b2edc15fab4a18b20ade408cabc725655038c0/src/main.js#L1079-L1086

This PR adds handling for dnsmasq_dhcp.

---

There are 3 files with similar logic:

1. /src/domains/dashboard/utils/render-charts-and-menu.ts
2. /src/domains/charts/getChartMenu.js
3. /src/main.js


I tested the changes using my branch + `npm run start:dashboard` and it is 3. to my understanding. 

> **Warning** I don't know if both 1. and 2. are used and how to test them.


Current (dnsmasq entry in dashboard_info.sh matches both collectors):

<img width="211" alt="Screenshot 2022-09-01 at 10 22 46" src="https://user-images.githubusercontent.com/22274335/187856009-c54029f6-d123-49ac-9fa0-918d17ad9658.png">

This PR:

<img width="218" alt="Screenshot 2022-09-01 at 10 23 32" src="https://user-images.githubusercontent.com/22274335/187856136-3ec2a51c-8559-4a4f-80fc-6cb4c7f4aa2c.png">

 