### PR TITLE
Added fallback for number chart to gauge.

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3211,6 +3211,7 @@ NETDATA.gaugeInitialize = function (callback) {
         })
             .done(function () {
                 NETDATA.registerChartLibrary('gauge', NETDATA.gauge_js);
+                NETDATA.registerChartLibrary('number', NETDATA.gauge_js);
             })
             .fail(function () {
                 NETDATA.chartLibraries.gauge.enabled = false;


### PR DESCRIPTION
- When we change the mainheads to use number chart (mainheads in dashboard_info.js), then agent will be backwards compatible using gauge chart.